### PR TITLE
Add /launch route to serve marketing page

### DIFF
--- a/app.py
+++ b/app.py
@@ -705,6 +705,13 @@ def landing():
     """Landing page with marketing content, pricing, and waitlist signup."""
     return render_template("landing.html", initial_user=_initial_user_payload())
 
+
+@app.get("/launch")
+def launch_page():
+    """Public launch page with waitlist form and FAQs."""
+    return render_template("launch.html", initial_user=_initial_user_payload())
+
+
 @app.get("/app")
 def index():
     """Main application page for authenticated users."""

--- a/tests/test_landing_page.py
+++ b/tests/test_landing_page.py
@@ -41,9 +41,17 @@ def test_app_route_exists(client):
     assert b'Swelly' in response.data
 
 
+def test_launch_page_renders(client):
+    """Launch marketing page should be available for waitlist signups."""
+    response = client.get('/launch')
+    assert response.status_code == 200
+    assert b'Launching Soon' in response.data or b'Join Waitlist' in response.data
+    assert b'launch' in response.data.lower()
+
+
 def test_waitlist_api_valid_email(client):
     """Test waitlist API with valid email."""
-    response = client.post('/api/waitlist', 
+    response = client.post('/api/waitlist',
                           json={'email': 'test@example.com'},
                           content_type='application/json')
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add Flask route for /launch to render the launch marketing page and waitlist form
- keep launch page consistent with other routes by passing the initial user payload
- add regression test to ensure the launch page renders successfully

## Testing
- pytest tests/test_landing_page.py::test_launch_page_renders

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fb5a7c9988328a4f4883f6cf6ce3e)