### PR TITLE
Add activity feed and ownership signals

### DIFF
--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -14,6 +14,82 @@ const generatedViewPrefs = {
   hiddenPlatforms: new Set(),
   loaded: false
 };
+const ACTIVITY_TYPE_META = {
+  generated: { label: 'Generated', icon: '✨', color: 'emerald' },
+  edited: { label: 'Edited', icon: '✏️', color: 'blue' },
+  commented: { label: 'Commented', icon: '💬', color: 'purple' },
+  approved: { label: 'Approved', icon: '✅', color: 'emerald' },
+  scheduled: { label: 'Scheduled', icon: '📅', color: 'amber' }
+};
+const activityEvents = [
+  {
+    id: 'act-1',
+    type: 'generated',
+    title: '3-day draft generated',
+    summary: 'IG + TikTok plan using “evergreen nurture” voice.',
+    campaign: 'Evergreen nurture',
+    assignee: 'Mia Nguyen',
+    actor: { name: 'Mia Nguyen', role: 'Strategist' },
+    time: '2m ago',
+    status: 'draft',
+    needsInputFrom: 'Tyler (client)',
+    platforms: ['instagram', 'short_video']
+  },
+  {
+    id: 'act-2',
+    type: 'edited',
+    title: 'Caption tightened for LinkedIn',
+    summary: 'Removed extra hashtags and added CTA for newsletter.',
+    campaign: 'Evergreen nurture',
+    assignee: 'Priya Shah',
+    actor: { name: 'Priya Shah', role: 'Editor' },
+    time: '8m ago',
+    status: 'in_progress',
+    platforms: ['linkedin']
+  },
+  {
+    id: 'act-3',
+    type: 'commented',
+    title: 'Client comment on carousel',
+    summary: '“Swap frame 1 hook for pain-point first.”',
+    campaign: 'Q4 product launch',
+    assignee: 'Mia Nguyen',
+    actor: { name: 'Daniel Brooks', role: 'Client' },
+    time: '24m ago',
+    status: 'draft',
+    needsInputFrom: 'Mia',
+    platforms: ['instagram']
+  },
+  {
+    id: 'act-4',
+    type: 'approved',
+    title: 'Legal approval granted',
+    summary: 'Scripts cleared for reels with promo language.',
+    campaign: 'Q4 product launch',
+    assignee: 'Tyler James',
+    actor: { name: 'Amelia Chen', role: 'Legal reviewer' },
+    time: '1h ago',
+    status: 'approved',
+    platforms: ['short_video']
+  },
+  {
+    id: 'act-5',
+    type: 'scheduled',
+    title: 'Two posts scheduled',
+    summary: 'Queued for Wed 9am and Fri 3pm with UTM swap.',
+    campaign: 'Retail holiday',
+    assignee: 'Priya Shah',
+    actor: { name: 'Jonas Lee', role: 'Marketing ops' },
+    time: '3h ago',
+    status: 'scheduled',
+    platforms: ['facebook', 'instagram']
+  }
+];
+const activityFilterState = {
+  types: new Set(Object.keys(ACTIVITY_TYPE_META)),
+  campaign: 'all',
+  assignee: 'all'
+};
 const planCacheState = {
   meta: null
 };
@@ -118,6 +194,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Feedback form in sidebar
   setupFeedbackForm();
+
+  // Activity and ownership feed
+  hydrateActivityFeed();
 
   hydrateVoiceSummary({});
   hydrateSeedPosts();
@@ -1107,6 +1186,152 @@ function showToast(message) {
   document.body.appendChild(toast);
   setTimeout(() => toast.classList.add('opacity-0'), 2200);
   setTimeout(() => toast.remove(), 2800);
+}
+
+function hydrateActivityFeed() {
+  const wrap = document.getElementById('activity-panel');
+  if (!wrap) return;
+  renderActivityTypeChips();
+  populateActivityFilterSelects();
+  bindActivityReset();
+  renderActivityFeed();
+}
+
+function renderActivityTypeChips() {
+  const wrap = document.getElementById('activity-type-filters');
+  if (!wrap) return;
+  wrap.innerHTML = '';
+  Object.entries(ACTIVITY_TYPE_META).forEach(([key, meta]) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.dataset.activityType = key;
+    btn.className = 'activity-chip';
+    btn.innerHTML = `<span class="activity-chip__icon">${meta.icon}</span><span>${meta.label}</span>`;
+    btn.classList.toggle('activity-chip--active', activityFilterState.types.has(key));
+    btn.addEventListener('click', () => {
+      if (activityFilterState.types.has(key)) {
+        activityFilterState.types.delete(key);
+      } else {
+        activityFilterState.types.add(key);
+      }
+      renderActivityTypeChips();
+      renderActivityFeed();
+    });
+    wrap.appendChild(btn);
+  });
+}
+
+function populateActivityFilterSelects() {
+  const campaignSelect = document.getElementById('activity-campaign-filter');
+  const assigneeSelect = document.getElementById('activity-assignee-filter');
+  const campaigns = Array.from(new Set(activityEvents.map(evt => evt.campaign).filter(Boolean)));
+  const assignees = Array.from(new Set(activityEvents.map(evt => evt.assignee).filter(Boolean)));
+
+  if (campaignSelect) {
+    campaignSelect.innerHTML = '<option value="all">All campaigns</option>' + campaigns.map(c => `<option value="${escapeAttr(c)}">${escapeHtml(c)}</option>`).join('');
+    campaignSelect.value = activityFilterState.campaign;
+    if (!campaignSelect.dataset.bound) {
+      campaignSelect.addEventListener('change', () => {
+        activityFilterState.campaign = campaignSelect.value;
+        renderActivityFeed();
+      });
+      campaignSelect.dataset.bound = '1';
+    }
+  }
+
+  if (assigneeSelect) {
+    assigneeSelect.innerHTML = '<option value="all">All teammates</option>' + assignees.map(a => `<option value="${escapeAttr(a)}">${escapeHtml(a)}</option>`).join('');
+    assigneeSelect.value = activityFilterState.assignee;
+    if (!assigneeSelect.dataset.bound) {
+      assigneeSelect.addEventListener('change', () => {
+        activityFilterState.assignee = assigneeSelect.value;
+        renderActivityFeed();
+      });
+      assigneeSelect.dataset.bound = '1';
+    }
+  }
+}
+
+function bindActivityReset() {
+  const btn = document.getElementById('activity-reset');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    activityFilterState.types = new Set(Object.keys(ACTIVITY_TYPE_META));
+    activityFilterState.campaign = 'all';
+    activityFilterState.assignee = 'all';
+    syncActivitySelects();
+    renderActivityTypeChips();
+    renderActivityFeed();
+  });
+}
+
+function syncActivitySelects() {
+  const campaignSelect = document.getElementById('activity-campaign-filter');
+  const assigneeSelect = document.getElementById('activity-assignee-filter');
+  if (campaignSelect) campaignSelect.value = activityFilterState.campaign;
+  if (assigneeSelect) assigneeSelect.value = activityFilterState.assignee;
+}
+
+function renderActivityFeed() {
+  const list = document.getElementById('activity-feed');
+  const empty = document.getElementById('activity-empty');
+  if (!list) return;
+  list.innerHTML = '';
+  const filtered = activityEvents.filter(evt => {
+    if (activityFilterState.types.size && !activityFilterState.types.has(evt.type)) return false;
+    if (activityFilterState.campaign !== 'all' && evt.campaign !== activityFilterState.campaign) return false;
+    if (activityFilterState.assignee !== 'all' && evt.assignee !== activityFilterState.assignee) return false;
+    return true;
+  });
+
+  filtered.forEach(evt => {
+    list.appendChild(buildActivityItem(evt));
+  });
+
+  if (empty) {
+    empty.classList.toggle('hidden', filtered.length > 0);
+  }
+}
+
+function buildActivityItem(evt) {
+  const meta = ACTIVITY_TYPE_META[evt.type] || { label: 'Update', icon: '•', color: 'slate' };
+  const item = document.createElement('article');
+  item.className = 'activity-item';
+  const role = evt.actor?.role ? `<span class="activity-role">${escapeHtml(evt.actor.role)}</span>` : '';
+  const needsInput = evt.status === 'draft' && evt.needsInputFrom ? `<span class="needs-input-pill">Needs input from ${escapeHtml(evt.needsInputFrom)}</span>` : '';
+  const campaignTag = evt.campaign ? `<span class="activity-pill">${escapeHtml(evt.campaign)}</span>` : '';
+  const assigneeTag = evt.assignee ? `<span class="activity-pill">Assignee: ${escapeHtml(evt.assignee)}</span>` : '';
+  const platforms = Array.isArray(evt.platforms) && evt.platforms.length ? `<div class="activity-platforms">${evt.platforms.map(formatPlatformLabel).join(' • ')}</div>` : '';
+  item.innerHTML = `
+    <div class="activity-item__header">
+      <span class="activity-type-badge activity-type-${meta.color}">${meta.icon} ${meta.label}</span>
+      <span class="activity-time">${escapeHtml(evt.time || '')}</span>
+    </div>
+    <div class="activity-item__body">
+      <div class="activity-avatar" aria-hidden="true">${escapeHtml(getInitials(evt.actor?.name))}</div>
+      <div class="activity-item__content">
+        <div class="activity-item__title">${escapeHtml(evt.title || 'Untitled update')}</div>
+        <div class="activity-item__meta">
+          <span class="activity-actor">${escapeHtml(evt.actor?.name || 'Unassigned')}</span>
+          ${role}
+          ${campaignTag}
+          ${assigneeTag}
+          ${needsInput}
+        </div>
+        <p class="activity-item__summary">${escapeHtml(evt.summary || '')}</p>
+        ${platforms}
+      </div>
+    </div>
+  `;
+  return item;
+}
+
+function getInitials(name = '') {
+  const parts = String(name || '').trim().split(/\s+/).filter(Boolean);
+  if (!parts.length) return '•';
+  const first = parts[0].charAt(0) || '';
+  const last = parts.length > 1 ? parts[parts.length - 1].charAt(0) : '';
+  return (first + last).toUpperCase();
 }
 
 // Render generated posts with enhanced features

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1208,6 +1208,7 @@ function renderActivityTypeChips() {
     btn.className = 'activity-chip';
     btn.innerHTML = `<span class="activity-chip__icon">${meta.icon}</span><span>${meta.label}</span>`;
     btn.classList.toggle('activity-chip--active', activityFilterState.types.has(key));
+    btn.setAttribute('aria-pressed', activityFilterState.types.has(key) ? 'true' : 'false');
     btn.addEventListener('click', () => {
       if (activityFilterState.types.has(key)) {
         activityFilterState.types.delete(key);

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1303,7 +1303,7 @@ function buildActivityItem(evt) {
   const needsInput = evt.status === 'draft' && evt.needsInputFrom ? `<span class="needs-input-pill">Needs input from ${escapeHtml(evt.needsInputFrom)}</span>` : '';
   const campaignTag = evt.campaign ? `<span class="activity-pill">${escapeHtml(evt.campaign)}</span>` : '';
   const assigneeTag = evt.assignee ? `<span class="activity-pill">Assignee: ${escapeHtml(evt.assignee)}</span>` : '';
-  const platforms = Array.isArray(evt.platforms) && evt.platforms.length ? `<div class="activity-platforms">${evt.platforms.map(formatPlatformLabel).join(' • ')}</div>` : '';
+  const platforms = Array.isArray(evt.platforms) && evt.platforms.length ? `<div class="activity-platforms">${evt.platforms.map(p => escapeHtml(formatPlatformLabel(p))).join(' • ')}</div>` : '';
   item.innerHTML = `
     <div class="activity-item__header">
       <span class="activity-type-badge activity-type-${meta.color}">${escapeHtml(meta.icon)} ${escapeHtml(meta.label)}</span>

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1212,10 +1212,11 @@ function renderActivityTypeChips() {
     btn.addEventListener('click', () => {
       if (activityFilterState.types.has(key)) {
         activityFilterState.types.delete(key);
+        btn.classList.remove('activity-chip--active');
       } else {
         activityFilterState.types.add(key);
+        btn.classList.add('activity-chip--active');
       }
-      renderActivityTypeChips();
       renderActivityFeed();
     });
     wrap.appendChild(btn);

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1306,7 +1306,7 @@ function buildActivityItem(evt) {
   const platforms = Array.isArray(evt.platforms) && evt.platforms.length ? `<div class="activity-platforms">${evt.platforms.map(formatPlatformLabel).join(' • ')}</div>` : '';
   item.innerHTML = `
     <div class="activity-item__header">
-      <span class="activity-type-badge activity-type-${meta.color}">${meta.icon} ${meta.label}</span>
+      <span class="activity-type-badge activity-type-${meta.color}">${escapeHtml(meta.icon)} ${escapeHtml(meta.label)}</span>
       <span class="activity-time">${escapeHtml(evt.time || '')}</span>
     </div>
     <div class="activity-item__body">

--- a/static/styles.css
+++ b/static/styles.css
@@ -94,6 +94,34 @@
 .generated-day__empty{ margin-top:.75rem; border:1px dashed #cbd5f5; border-radius:12px; padding:.75rem 1rem; font-size:.85rem; color:#64748b; background:#f8fafc; }
 .generated-day.is-filter-empty .generated-day__body{ opacity:.75; }
 
+.activity-label{ font-size:.72rem; letter-spacing:.15em; text-transform:uppercase; color:#94a3b8; margin-bottom:.35rem; font-weight:700; }
+.activity-type-chips{ display:flex; flex-wrap:wrap; gap:.5rem; }
+.activity-chip{ border:1px solid #e2e8f0; background:#fff; border-radius:999px; padding:.45rem .85rem; font-size:.85rem; font-weight:600; color:#334155; display:inline-flex; align-items:center; gap:.4rem; transition:all .2s ease; box-shadow:0 6px 12px rgba(15,23,42,.04); }
+.activity-chip__icon{ font-size:1rem; }
+.activity-chip--active{ border-color:var(--brand); color:var(--brand); background:rgba(99,102,241,.08); box-shadow:0 10px 24px rgba(99,102,241,.16); }
+.activity-feed{ border-top:1px solid #e2e8f0; padding-top:1rem; }
+.activity-empty{ margin-top:1rem; font-size:.9rem; color:#6b7280; border:1px dashed #cbd5f5; border-radius:12px; padding:0.85rem 1rem; background:#f8fafc; }
+.activity-item{ border:1px solid #e2e8f0; border-radius:16px; padding:1rem; background:linear-gradient(135deg,#fff,#f8fafc); box-shadow:0 12px 28px rgba(15,23,42,.05); }
+.activity-item__header{ display:flex; justify-content:space-between; align-items:center; gap:.75rem; margin-bottom:.75rem; }
+.activity-type-badge{ display:inline-flex; align-items:center; gap:.4rem; font-size:.8rem; font-weight:700; padding:.35rem .7rem; border-radius:999px; border:1px solid transparent; }
+.activity-type-emerald{ background:#ecfdf3; color:#0f766e; border-color:#a7f3d0; }
+.activity-type-blue{ background:#eff6ff; color:#1d4ed8; border-color:#bfdbfe; }
+.activity-type-purple{ background:#f3e8ff; color:#6d28d9; border-color:#e9d5ff; }
+.activity-type-amber{ background:#fff7ed; color:#b45309; border-color:#fed7aa; }
+.activity-type-slate{ background:#e2e8f0; color:#0f172a; border-color:#cbd5e1; }
+.activity-time{ font-size:.82rem; color:#94a3b8; }
+.activity-item__body{ display:grid; grid-template-columns:auto 1fr; gap:.85rem; align-items:flex-start; }
+.activity-avatar{ width:40px; height:40px; border-radius:999px; background:linear-gradient(135deg,#c7d2fe,#eef2ff); color:#312e81; display:flex; align-items:center; justify-content:center; font-weight:800; box-shadow:0 6px 16px rgba(99,102,241,.18); }
+.activity-item__content{ display:flex; flex-direction:column; gap:.4rem; }
+.activity-item__title{ font-weight:700; color:#0f172a; font-size:1rem; }
+.activity-item__meta{ display:flex; flex-wrap:wrap; gap:.4rem; align-items:center; }
+.activity-actor{ font-weight:700; color:#111827; }
+.activity-role{ background:#eef2ff; color:#4338ca; border-radius:999px; padding:.2rem .65rem; font-size:.78rem; font-weight:700; }
+.activity-pill{ background:#f1f5f9; color:#475569; border-radius:999px; padding:.25rem .7rem; font-size:.78rem; font-weight:600; }
+.needs-input-pill{ background:#fef9c3; color:#854d0e; border-radius:12px; padding:.3rem .75rem; font-size:.8rem; font-weight:700; box-shadow:0 6px 18px rgba(245,158,11,.18); }
+.activity-item__summary{ font-size:.9rem; color:#475569; margin:0; }
+.activity-platforms{ font-size:.82rem; color:#6366f1; font-weight:700; letter-spacing:.02em; }
+
 .planner-card{ border:1px solid #e2e8f0; border-radius:32px; padding:2rem; background:#fff; box-shadow:0 20px 60px rgba(15,23,42,.04); }
 .planner-row{ display:grid; grid-template-columns: minmax(140px,220px) 1fr; gap:1.5rem; align-items:flex-start; }
 .planner-label{ text-transform:uppercase; font-size:.72rem; letter-spacing:.35em; color:#94a3b8; font-weight:600; padding-top:.35rem; }

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -474,6 +474,38 @@
         </div>
       </div>
 
+      <div class="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-slate-200" id="activity-panel">
+        <div class="flex items-start justify-between gap-3 mb-4">
+          <div>
+            <p class="planner-eyebrow mb-1">Team signals</p>
+            <h4 class="text-lg font-semibold text-slate-900">Activity feed</h4>
+            <p class="text-sm text-slate-600">Trace ownership and approvals without leaving the planner.</p>
+          </div>
+          <button type="button" class="btn-ghost btn-sm" id="activity-reset">Reset</button>
+        </div>
+
+        <div class="space-y-3">
+          <div>
+            <p class="activity-label">Event types</p>
+            <div id="activity-type-filters" class="activity-type-chips"></div>
+          </div>
+
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label class="text-xs font-semibold text-slate-600 flex flex-col gap-1">
+              Campaign
+              <select id="activity-campaign-filter" class="input text-sm"></select>
+            </label>
+            <label class="text-xs font-semibold text-slate-600 flex flex-col gap-1">
+              Assignee
+              <select id="activity-assignee-filter" class="input text-sm"></select>
+            </label>
+          </div>
+        </div>
+
+        <div id="activity-feed" class="activity-feed space-y-3 mt-4"></div>
+        <div id="activity-empty" class="activity-empty hidden">No activity matches these filters yet.</div>
+      </div>
+
       <div class="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-slate-200">
         <h4 class="text-lg font-semibold mb-2 text-slate-900">Feedback & requests</h4>
         <p class="text-sm text-slate-600 mb-4">Tell us what to polish next. We'll get it to the team.</p>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -485,10 +485,10 @@
         </div>
 
         <div class="space-y-3">
-          <div>
-            <p class="activity-label">Event types</p>
+          <fieldset>
+            <legend class="activity-label">Event types</legend>
             <div id="activity-type-filters" class="activity-type-chips"></div>
-          </div>
+          </fieldset>
 
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <label class="text-xs font-semibold text-slate-600 flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- add dashboard sidebar activity feed with event type chips and campaign/assignee filters
- render ownership signals, avatars, and needs-input tags for draft updates
- style the activity feed to align with existing planner components

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fbe06606083288d7e9ab5b14adc5c)