### PR TITLE
Improve logout and admin team workflows

### DIFF
--- a/app.py
+++ b/app.py
@@ -2121,8 +2121,9 @@ def api_login():
 
 @app.post('/api/logout')
 def api_logout():
-    session.pop('user_id', None)
-    session.pop('profile_id', None)
+    # Clear all session state instead of removing only auth keys to avoid
+    # leaving behind admin CSRF tokens or feature flags between accounts.
+    session.clear()
     return jsonify({'ok': True})
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -330,7 +330,9 @@ let skipStep2 = false;
 
 // load optional flags then config (share promise for later waits)
 const bootPromise = loadFlags().then(loadConfig).catch(err => { console.error(err); });
-bootPromise.then(() => hydrateWizardPreview());
+bootPromise
+  .then(() => hydrateWizardPreview())
+  .catch(() => hydrateWizardPreview());
 
 // attempt to load saved profile for this session and prefill fields
 async function loadSavedProfile(){

--- a/templates/account.html
+++ b/templates/account.html
@@ -309,6 +309,8 @@
         document.getElementById('team-approval-list')?.addEventListener('click', handleApprovalListClick);
       } else if (approvalsSection && !hasTeamAccess) {
         setApprovalStatus('Upgrade to a team plan to use approvals.', 'muted');
+        const submitBtn = document.getElementById('team-approval-submit');
+        if (submitBtn) submitBtn.disabled = true;
         document.getElementById('team-approval-form')?.setAttribute('aria-disabled', 'true');
       }
 

--- a/templates/account.html
+++ b/templates/account.html
@@ -233,6 +233,7 @@
 
   <script>
     document.addEventListener('DOMContentLoaded', () => {
+      const hasTeamAccess = (document.body?.dataset.teamAccess === '1') || (document.body?.dataset.isAdmin === '1');
       const manage = document.getElementById('manage-sub');
       const subscribe = document.getElementById('subscribe-now');
       if (manage) manage.addEventListener('click', async () => {
@@ -301,11 +302,14 @@
 
       const approvalsSection = document.getElementById('team-approvals');
       const approvalsState = { items: [] };
-      if (approvalsSection) {
+      if (approvalsSection && hasTeamAccess) {
         loadTeamApprovals();
         document.getElementById('team-approvals-refresh')?.addEventListener('click', () => loadTeamApprovals());
         document.getElementById('team-approval-form')?.addEventListener('submit', handleApprovalSubmit);
         document.getElementById('team-approval-list')?.addEventListener('click', handleApprovalListClick);
+      } else if (approvalsSection && !hasTeamAccess) {
+        setApprovalStatus('Upgrade to a team plan to use approvals.', 'muted');
+        document.getElementById('team-approval-form')?.setAttribute('aria-disabled', 'true');
       }
 
       async function hydrateAdminPanel(){


### PR DESCRIPTION
## Summary
- clear all session data on logout to fully sign users out of admin features
- guard team approval tools to only initialize for team or admin accounts and provide clearer messaging otherwise
- ensure generate page preview always renders sample content even when config fetch fails

## Testing
- pytest tests/test_admin_users.py tests/test_account_subscription_state.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210eda41888328b7081d6004feb520)