### PR TITLE
Add platform-specific variant generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2383,7 +2383,6 @@ def api_generate_variants():
     data = request.get_json(force=True) or {}
     industry = (data.get('industry') or 'Business').strip() or 'Business'
     tone = (data.get('tone') or 'friendly').strip() or 'friendly'
-    platform = (data.get('platform') or 'instagram').strip() or 'instagram'
     try:
         count = int(data.get('count') or 3)
     except Exception:
@@ -2391,12 +2390,25 @@ def api_generate_variants():
     count = max(1, min(count, 10))
     brand_keywords = _coerce_str_list(data.get('brand_keywords'), [])
     goals = _coerce_str_list(data.get('goals'), [])
-    variants = []
+    variant_groups = []
+    hashtags = gen_mod.default_hashtags(industry, brand_keywords)
     for idx in range(count):
         pillar_name, pillar_hint = gen_mod.PILLARS_BY_DEFAULT[idx % len(gen_mod.PILLARS_BY_DEFAULT)]
-        caption = gen_mod.make_caption(industry, tone, pillar_name, pillar_hint, platform, brand_keywords, gen_mod.default_hashtags(industry, brand_keywords), goals)
-        variants.append({'platform': platform, 'pillar': pillar_name, 'caption': caption})
-    return jsonify({'ok': True, 'variants': variants})
+        variants = gen_mod.build_platform_variants(
+            industry=industry,
+            tone=tone,
+            pillar_name=pillar_name,
+            pillar_hint=pillar_hint,
+            base_platform='instagram',
+            brand_keywords=brand_keywords,
+            hashtags=hashtags,
+            goals=goals,
+            company=data.get('company') or '',
+            theme=data.get('theme'),
+            platforms=list(gen_mod.DEFAULT_VARIANT_PLATFORMS)
+        )
+        variant_groups.append({'pillar': pillar_name, 'variants': variants})
+    return jsonify({'ok': True, 'variants': variant_groups})
 
 
 @app.post('/api/feedback')

--- a/generator.py
+++ b/generator.py
@@ -186,6 +186,30 @@ def default_hashtags(industry: str, niche_keywords: list[str]):
 def build_platform_variants(industry: str, tone: str, pillar_name: str, pillar_hint: str,
                             base_platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str],
                             company: str = "", theme: Optional[str] = None, platforms: Optional[list[str]] = None):
+    """
+    Generate platform-specific variants of a caption by applying platform rules to a base caption body.
+
+    This function first generates a base caption body using the specified `base_platform` (which determines
+    the style and structure of the initial text). It then applies platform-specific formatting and rules
+    to produce variants for each target platform in `platforms`.
+
+    Parameters:
+        industry (str): The industry or business type for which the caption is generated.
+        tone (str): The desired tone of the caption (e.g., friendly, professional).
+        pillar_name (str): The content pillar name (e.g., "Educational", "Testimonial").
+        pillar_hint (str): A hint or prompt for the content pillar.
+        base_platform (str): The platform whose style is used to generate the initial caption body.
+        brand_keywords (list[str]): List of keywords or phrases relevant to the brand.
+        hashtags (list[str]): List of hashtags to include in the variants.
+        goals (list[str]): List of business or post goals.
+        company (str, optional): The company or brand name. Defaults to "".
+        theme (str, optional): An optional theme for the post. Defaults to None.
+        platforms (list[str], optional): List of platform keys for which to generate variants.
+            If None, uses DEFAULT_VARIANT_PLATFORMS.
+
+    Returns:
+        dict[str, Any]: A dictionary mapping each platform key to its variant payload (caption text and metadata).
+    """
     body = build_caption_body(industry, tone, pillar_name, pillar_hint, base_platform, brand_keywords, goals, company, theme)
     variant_targets = list(platforms or DEFAULT_VARIANT_PLATFORMS)
     variants = {}

--- a/generator.py
+++ b/generator.py
@@ -6,6 +6,8 @@ from datetime import timedelta, date
 from pathlib import Path
 from typing import Optional, Any, Mapping, Sequence
 
+from platform_rules import DEFAULT_VARIANT_PLATFORMS, apply_platform_rules
+
 PILLARS_BY_DEFAULT = [
     ("Educational", "Share a quick tip that solves a common problem for your audience."),
     ("Behind-the-Scenes", "Show a candid look at your process, team, or workspace."),
@@ -180,13 +182,24 @@ def default_hashtags(industry: str, niche_keywords: list[str]):
             seen.add(t_low)
     return tags[:12]
 
+
+def build_platform_variants(industry: str, tone: str, pillar_name: str, pillar_hint: str,
+                            base_platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str],
+                            company: str = "", theme: Optional[str] = None, platforms: Optional[list[str]] = None):
+    body = build_caption_body(industry, tone, pillar_name, pillar_hint, base_platform, brand_keywords, goals, company, theme)
+    variant_targets = list(platforms or DEFAULT_VARIANT_PLATFORMS)
+    variants = {}
+    for platform in variant_targets:
+        variants[platform] = apply_platform_rules(body, platform, hashtags, pillar_name=pillar_name, goals=goals, company=company)
+    return variants
+
 def to_sentence_case(s: str):
     if not s:
         return s
     return s[0].upper() + s[1:]
 
-def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
-                 platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str], company: str = "", theme: Optional[str] = None):
+def build_caption_body(industry: str, tone: str, pillar_name: str, pillar_hint: str,
+                       platform: str, brand_keywords: list[str], goals: list[str], company: str = "", theme: Optional[str] = None) -> str:
     tone_blurb = {
         "friendly": "Warm, encouraging, and conversational.",
         "professional": "Clear, confident, and value-focused.",
@@ -210,9 +223,16 @@ def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
         f"Platform tip: {platform_hint}\n\n"
         f"CTA: Tell us what you think below 👇"
     )
+    return body
 
+
+def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
+                 platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str], company: str = "", theme: Optional[str] = None):
+    body = build_caption_body(industry, tone, pillar_name, pillar_hint, platform, brand_keywords, goals, company, theme)
     tags = " ".join(hashtags)
-    return f"{body}\n\n{tags}"
+    if tags:
+        return f"{body}\n\n{tags}"
+    return body
 
 def make_full_post(industry: str, tone: str, pillar_name: str, pillar_hint: str,
                    platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str], company: str = "", theme: Optional[str] = None):
@@ -651,25 +671,25 @@ def generate_posts(
         pillar_name, pillar_hint = next(pillar_stream)
 
         # Generate platform-specific variants for this day
-        variants = {}
-        for p in platforms:
-            caption = make_caption(
-                industry=to_sentence_case(industry),
-                tone=tone,
-                pillar_name=pillar_name,
-                pillar_hint=pillar_hint,
-                platform=p,
-                brand_keywords=brand_keywords,
-                hashtags=hashtags,
-                goals=goals,
-                company=company,
-                theme=details.get("note")
-            )
-            variants[p] = caption
+        variant_platforms = sorted(set(list(DEFAULT_VARIANT_PLATFORMS) + list(platforms)))
+        variants = build_platform_variants(
+            industry=to_sentence_case(industry),
+            tone=tone,
+            pillar_name=pillar_name,
+            pillar_hint=pillar_hint,
+            base_platform=platforms[0],
+            brand_keywords=brand_keywords,
+            hashtags=hashtags,
+            goals=goals,
+            company=company,
+            theme=details.get("note"),
+            platforms=variant_platforms
+        )
 
         # Create one post per platform (maintains backward compatibility)
         for p in platforms:
-            caption = variants[p]
+            variant_payload = variants.get(p, {}) if isinstance(variants, dict) else {}
+            caption = variant_payload.get('text') if isinstance(variant_payload, dict) else variant_payload
             iprompt = image_prompt(industry, pillar_name, brand_keywords, company)
             img_url = unsplash_link(industry, pillar_name) if include_images else None
 
@@ -701,10 +721,13 @@ def generate_posts(
                 "platform": p,
                 "pillar": pillar_name,
                 "caption": caption,
+                "warnings": variant_payload.get('warnings') if isinstance(variant_payload, dict) else None,
+                "cta": variant_payload.get('cta') if isinstance(variant_payload, dict) else None,
+                "thumbnail_note": variant_payload.get('thumbnail_note') if isinstance(variant_payload, dict) else None,
                 "image_prompt": iprompt,
                 "image_url": img_url,
                 "reel": reel_obj,
-                "variants": variants if len(platforms) > 1 else None
+                "variants": variants
             })
 
     return posts

--- a/generator.py
+++ b/generator.py
@@ -200,6 +200,29 @@ def to_sentence_case(s: str):
 
 def build_caption_body(industry: str, tone: str, pillar_name: str, pillar_hint: str,
                        platform: str, brand_keywords: list[str], goals: list[str], company: str = "", theme: Optional[str] = None) -> str:
+    """
+    Generate the main body content for a social media caption, without hashtags.
+
+    This function is used as an intermediate step before applying platform-specific rules
+    (such as formatting or hashtag insertion). It returns a formatted string containing
+    the core caption content, ready for further processing.
+
+    Differs from `make_caption`, which adds hashtags and may apply additional formatting.
+
+    Args:
+        industry: The industry or business type.
+        tone: The desired tone for the caption.
+        pillar_name: The content pillar (e.g., "Educational").
+        pillar_hint: A hint or prompt for the pillar.
+        platform: The target platform (used for platform hints).
+        brand_keywords: List of brand or business keywords.
+        goals: List of business or post goals.
+        company: (Optional) Company name.
+        theme: (Optional) Theme for the post.
+
+    Returns:
+        str: The formatted caption body, ready for platform-specific rule application.
+    """
     tone_blurb = {
         "friendly": "Warm, encouraging, and conversational.",
         "professional": "Clear, confident, and value-focused.",

--- a/platform_rules.py
+++ b/platform_rules.py
@@ -150,7 +150,10 @@ def apply_platform_rules(
     if goal_hint:
         cta_line = f"{cta_line} ({goal_hint})."
     if rule.link_note:
-        cta_line = f"{cta_line} {rule.link_note}"
+        # Ensure there is a space after the period if needed
+        if not cta_line.endswith(('.', '!', '?')):
+            cta_line += '.'
+        cta_line = f"{cta_line} {rule.link_note.strip()}"
 
     hashtag_block = " ".join(cleaned_hashtags)
     parts = [body.strip(), "", cta_line]

--- a/platform_rules.py
+++ b/platform_rules.py
@@ -1,0 +1,186 @@
+"""Shared platform rules and heuristics for generating channel-specific copy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Tuple
+
+
+@dataclass
+class PlatformRule:
+    key: str
+    label: str
+    max_length: int
+    max_hashtags: int
+    cta: str
+    hashtag_prefix: str = "#"
+    hashtag_position: str = "end"
+    link_note: str | None = None
+    thumbnail_note: str | None = None
+
+
+PLATFORM_RULES: dict[str, PlatformRule] = {
+    "twitter": PlatformRule(
+        key="twitter",
+        label="X / Twitter",
+        max_length=260,
+        max_hashtags=3,
+        cta="Reply with your take or tag a friend",
+        link_note="Keep URLs short; avoid more than one link.",
+        thumbnail_note="Lead with the hook in frame 1 for the preview",
+    ),
+    "linkedin": PlatformRule(
+        key="linkedin",
+        label="LinkedIn",
+        max_length=1100,
+        max_hashtags=5,
+        cta="Add your perspective below or DM for details",
+        link_note="Link after the first 1–2 lines so the intro hooks readers.",
+        thumbnail_note="Use a bold headline overlay that matches the hook",
+    ),
+    "instagram": PlatformRule(
+        key="instagram",
+        label="Instagram",
+        max_length=2000,
+        max_hashtags=12,
+        cta="Save + share if this helps; link in bio for more",
+        hashtag_prefix="#",
+        hashtag_position="end",
+        thumbnail_note="Cover text: 3–5 words, high contrast, subject centered",
+    ),
+    "facebook": PlatformRule(
+        key="facebook",
+        label="Facebook",
+        max_length=1200,
+        max_hashtags=4,
+        cta="Drop a comment or share with someone who needs this",
+        thumbnail_note="Use a friendly face and a single bold line of text",
+    ),
+    "tiktok": PlatformRule(
+        key="tiktok",
+        label="TikTok",
+        max_length=1500,
+        max_hashtags=5,
+        cta="Try it and tell us how it goes in the comments",
+        hashtag_prefix="#",
+        link_note="Keep the CTA verbal—links are less visible here.",
+        thumbnail_note="Hook in 4 words max. High-contrast caption on frame 1.",
+    ),
+    "youtube": PlatformRule(
+        key="youtube",
+        label="YouTube Shorts",
+        max_length=5000,
+        max_hashtags=6,
+        cta="Subscribe for more and check the pinned link",
+        hashtag_prefix="#",
+        hashtag_position="end",
+        thumbnail_note="Thumbnail: bold promise + clear subject, avoid clutter",
+    ),
+}
+
+
+DEFAULT_VARIANT_PLATFORMS: Tuple[str, ...] = (
+    "twitter",
+    "linkedin",
+    "instagram",
+    "facebook",
+    "tiktok",
+    "youtube",
+)
+
+
+def truncate_with_ellipsis(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    if limit <= 1:
+        return text[:limit]
+    return text[: max(limit - 1, 0)].rstrip() + "…"
+
+
+def format_hashtags(raw: Iterable[str], max_count: int, prefix: str = "#") -> Tuple[List[str], bool]:
+    cleaned: List[str] = []
+    seen = set()
+    for tag in raw:
+        if not tag:
+            continue
+        tag_str = str(tag).strip()
+        if not tag_str:
+            continue
+        if not tag_str.startswith(prefix):
+            tag_str = f"{prefix}{tag_str}"
+        tag_key = tag_str.lower()
+        if tag_key in seen:
+            continue
+        seen.add(tag_key)
+        cleaned.append(tag_str)
+    trimmed = False
+    if len(cleaned) > max_count:
+        cleaned = cleaned[:max_count]
+        trimmed = True
+    return cleaned, trimmed
+
+
+def apply_platform_rules(
+    body: str,
+    platform: str,
+    hashtags: Iterable[str],
+    pillar_name: str | None = None,
+    goals: Iterable[str] | None = None,
+    company: str | None = None,
+) -> dict:
+    platform_key = (platform or "").lower()
+    rule = PLATFORM_RULES.get(platform_key)
+    if not rule:
+        rule = PlatformRule(
+            key=platform_key or "default",
+            label=platform or "Default",
+            max_length=1500,
+            max_hashtags=5,
+            cta="Comment or share if this resonates",
+            thumbnail_note=None,
+        )
+
+    warnings: List[str] = []
+    cleaned_hashtags, trimmed = format_hashtags(hashtags, rule.max_hashtags, rule.hashtag_prefix)
+    if trimmed:
+        warnings.append(f"Trimmed hashtags to {rule.max_hashtags} for {rule.label}.")
+
+    goal_hint = ", ".join(goals or [])
+    cta_line = rule.cta
+    if goal_hint:
+        cta_line = f"{cta_line} ({goal_hint})."
+    if rule.link_note:
+        cta_line = f"{cta_line} {rule.link_note}"
+
+    hashtag_block = " ".join(cleaned_hashtags)
+    parts = [body.strip(), "", cta_line]
+    if rule.hashtag_position == "end" and hashtag_block:
+        parts.extend(["", hashtag_block])
+    composed = "\n".join([p for p in parts if p != ""])
+
+    if len(composed) > rule.max_length:
+        allowed_body = max(rule.max_length - len(cta_line) - len(hashtag_block) - 4, 80)
+        trimmed_body = truncate_with_ellipsis(body.strip(), allowed_body)
+        warnings.append(f"Trimmed copy to fit {rule.label} limit of {rule.max_length} characters.")
+        parts = [trimmed_body, "", cta_line]
+        if rule.hashtag_position == "end" and hashtag_block:
+            parts.extend(["", hashtag_block])
+        composed = "\n".join([p for p in parts if p != ""])
+
+    variant_payload = {
+        "text": composed,
+        "warnings": warnings,
+        "hashtags": cleaned_hashtags,
+        "cta": cta_line,
+        "thumbnail_note": rule.thumbnail_note,
+        "platform": platform_key,
+        "platform_label": rule.label,
+    }
+
+    if rule.thumbnail_note:
+        context_hint = pillar_name or company
+        if context_hint and "{" not in rule.thumbnail_note:
+            variant_payload["thumbnail_note"] = f"{rule.thumbnail_note} ({context_hint})"
+
+    return variant_payload
+

--- a/platform_rules.py
+++ b/platform_rules.py
@@ -159,13 +159,33 @@ def apply_platform_rules(
     composed = "\n".join([p for p in parts if p != ""])
 
     if len(composed) > rule.max_length:
-        allowed_body = max(rule.max_length - len(cta_line) - len(hashtag_block) - 4, 80)
+        # Calculate the fixed length of non-body parts (CTA, hashtags, separators)
+        sep_cta = 1 if cta_line else 0  # newline before CTA
+        sep_hash = 1 if (rule.hashtag_position == "end" and hashtag_block) else 0  # newline before hashtags
+        # Number of newlines: between body and CTA, and between CTA and hashtags if present
+        non_body_parts = ""
+        if cta_line:
+            non_body_parts += ("\n" if non_body_parts else "") + cta_line
+        if rule.hashtag_position == "end" and hashtag_block:
+            non_body_parts += "\n" + hashtag_block
+        non_body_length = len(non_body_parts)
+        # Also account for the newline after the body if CTA or hashtags are present
+        if non_body_parts:
+            non_body_length += 1  # newline after body
+        allowed_body = rule.max_length - non_body_length
+        if allowed_body < 0:
+            allowed_body = 0
         trimmed_body = truncate_with_ellipsis(body.strip(), allowed_body)
         warnings.append(f"Trimmed copy to fit {rule.label} limit of {rule.max_length} characters.")
-        parts = [trimmed_body, "", cta_line]
+        parts = [trimmed_body] if trimmed_body else []
+        if cta_line:
+            parts.append(cta_line)
         if rule.hashtag_position == "end" and hashtag_block:
-            parts.extend(["", hashtag_block])
-        composed = "\n".join([p for p in parts if p != ""])
+            parts.append(hashtag_block)
+        composed = "\n".join(parts)
+        # As a last resort, if composed is still too long (due to unexpected formatting), truncate the whole thing
+        if len(composed) > rule.max_length:
+            composed = truncate_with_ellipsis(composed, rule.max_length)
 
     variant_payload = {
         "text": composed,

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1239,10 +1239,24 @@ function buildPostSnapshot(post = {}) {
     lines.push('Platform variants:');
     Object.keys(post.variants).forEach(key => {
       lines.push(`- ${formatPlatformLabel(key)}:`);
-      lines.push(post.variants[key]);
+      const entry = normalizeVariantPayload(post.variants[key]);
+      lines.push(entry.text || '');
     });
   }
   return lines.join('\n');
+}
+
+function normalizeVariantPayload(entry) {
+  if (!entry) return { text: '', warnings: [] };
+  if (typeof entry === 'string') return { text: entry, warnings: [] };
+  return {
+    text: entry.text || '',
+    warnings: Array.isArray(entry.warnings) ? entry.warnings : [],
+    cta: entry.cta || '',
+    thumbnail_note: entry.thumbnail_note || '',
+    platform: entry.platform || '',
+    platform_label: entry.platform_label || formatPlatformLabel(entry.platform || '')
+  };
 }
 
 function buildPostSummary(post = {}) {
@@ -1252,6 +1266,11 @@ function buildPostSummary(post = {}) {
   const firstLine = (post.caption || '').split('\n')[0].trim();
   const snippet = firstLine.length > 60 ? `${firstLine.slice(0, 57)}…` : firstLine;
   return `${platformLabel} ${day}`.trim() + (pillar || '') + (snippet ? ` • ${snippet}` : '');
+}
+
+function renderWarningList(warnings) {
+  if (!warnings || !warnings.length) return '';
+  return `<div class="flex flex-col gap-1 my-2">${warnings.map(note => `<div class=\"flex items-center gap-2 text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2\"><span aria-hidden=\"true\">⚠️</span><span>${escapeHtml(note)}</span></div>`).join('')}</div>`;
 }
 
 // Render individual post card with enhanced features
@@ -1275,6 +1294,7 @@ function renderPostCard(post) {
   const editorId = `post-editor-${post.day_index}-${post.platform}-${Math.random().toString(36).slice(2,7)}`;
   const stampId = `${editorId}-stamp`;
   const variantsMarkup = post.variants ? renderPlatformVariants(post.variants, post.platform) : '';
+  const warningMarkup = renderWarningList(post.warnings);
 
   // Check if this post has variants (multiple platforms)
   const hasVariants = post.variants && Object.keys(post.variants).length > 1;
@@ -1301,6 +1321,7 @@ function renderPostCard(post) {
     <div class="text-xs text-slate-500 mb-2"><strong>Image prompt:</strong> ${escapeHtml(post.image_prompt)}</div>
 
     <label class="text-xs font-semibold text-slate-500 tracking-wide">Caption</label>
+    ${warningMarkup}
     <textarea id="${editorId}" class="post-editor mb-3" data-platform="${post.platform}">${escapeHtml(post.caption)}</textarea>
 
     ${post.reel ? renderReelSection(post.reel) : ''}
@@ -1327,6 +1348,25 @@ function renderPostCard(post) {
     const targetEditor = targetId ? card.querySelector(`#${targetId}`) : null;
     const stampEl = stampTarget ? card.querySelector(`#${stampTarget}`) : null;
     bindCopyButton(btn, targetEditor, stampEl, card);
+  });
+
+  card.querySelectorAll('[data-export-variants]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const chunks = [];
+      card.querySelectorAll('[data-variant-text]').forEach(area => {
+        const platform = area.getAttribute('data-variant-platform') || 'Platform';
+        const label = formatPlatformLabel(platform) || platform;
+        chunks.push(`${label}:\n${area.value.trim()}`);
+      });
+      const exportText = chunks.join('\n\n');
+      try {
+        await navigator.clipboard.writeText(exportText);
+        showToast('Copied all variants to clipboard');
+      } catch (err) {
+        console.error('Failed to export variants', err);
+        showToast('Unable to copy variants right now.');
+      }
+    });
   });
 
   card.querySelectorAll('[data-like]').forEach(btn => {
@@ -1425,24 +1465,43 @@ function renderReelSection(reel) {
 function renderPlatformVariants(variants, currentPlatform) {
   if (!variants) return '';
 
-  const otherPlatforms = Object.keys(variants).filter(p => p !== currentPlatform);
-  if (otherPlatforms.length === 0) return '';
+  const entries = Object.entries(variants).map(([platform, value]) => {
+    return { platform, data: normalizeVariantPayload(value) };
+  });
+  if (!entries.length) return '';
 
   return `
-    <div class="mt-3 p-3 bg-blue-50 rounded border-l-4 border-blue-400">
-      <div class="text-sm font-medium text-blue-900 mb-2">Platform Variants:</div>
-      <div class="space-y-2">
-        ${otherPlatforms.map(platform => {
+    <div class="mt-3 p-3 bg-blue-50 rounded-2xl border border-blue-100">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-2 text-sm font-medium text-blue-900">
+          <span>Platform variants</span>
+          <span class="text-xs text-blue-700">Tuned for each channel</span>
+        </div>
+        <button type="button" class="btn-ghost text-xs" data-export-variants>Export all</button>
+      </div>
+      <div class="grid gap-3 md:grid-cols-2">
+        ${entries.map(({ platform, data }) => {
           const editorId = `variant-${platform}-${Math.random().toString(36).slice(2,8)}`;
           const stampId = `${editorId}-stamp`;
+          const warnings = renderWarningList(data.warnings);
+          const badge = platform === currentPlatform ? '<span class="text-[11px] text-emerald-700 bg-emerald-100 px-2 py-0.5 rounded-full">Selected</span>' : '';
+          const thumb = data.thumbnail_note ? `<p class="text-[11px] text-blue-800 bg-blue-100 rounded px-2 py-1">Thumbnail: ${escapeHtml(data.thumbnail_note)}</p>` : '';
           return `
-            <div class="space-y-1">
-              <div class="flex items-center gap-2 flex-wrap">
-                <span class="text-xs font-medium text-blue-700 capitalize">${platform}:</span>
-                <button class="btn-ghost text-xs" data-copy-target="${editorId}" data-stamp-target="${stampId}">Copy</button>
-                <span id="${stampId}" class="copy-timestamp"></span>
+            <div class="bg-white rounded-xl border border-blue-100 p-3 shadow-sm" data-variant-card>
+              <div class="flex items-center justify-between gap-2 mb-2">
+                <div class="flex items-center gap-2">
+                  <span class="text-xs font-semibold text-blue-900">${formatPlatformLabel(platform)}</span>
+                  ${badge}
+                </div>
+                <div class="flex items-center gap-2">
+                  <button class="btn-ghost text-[11px]" data-copy-target="${editorId}" data-stamp-target="${stampId}">Copy</button>
+                  <span id="${stampId}" class="copy-timestamp"></span>
+                </div>
               </div>
-              <textarea id="${editorId}" class="post-editor post-editor--compact">${escapeHtml(variants[platform])}</textarea>
+              ${thumb}
+              ${warnings}
+              <textarea id="${editorId}" class="post-editor post-editor--compact" data-variant-text data-variant-platform="${platform}">${escapeHtml(data.text)}</textarea>
+              ${data.cta ? `<p class="text-[11px] text-slate-600 mt-2">CTA: ${escapeHtml(data.cta)}</p>` : ''}
             </div>
           `;
         }).join('')}

--- a/tests/test_generate_variants.py
+++ b/tests/test_generate_variants.py
@@ -23,6 +23,12 @@ def test_generate_variants_fallback(monkeypatch):
     assert data and data.get('ok') is True
     assert 'variants' in data
     assert len(data['variants']) == 3
+    first_group = data['variants'][0]
+    assert 'variants' in first_group
+    payload = first_group['variants']
+    assert 'twitter' in payload and 'youtube' in payload
+    assert isinstance(payload['twitter'], dict)
+    assert payload['twitter'].get('text')
 
 
 def test_generate_variants_requires_auth_in_prod(monkeypatch):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -33,20 +33,21 @@ def test_generate_posts_with_variants():
     # Should have 3 posts (one per platform)
     assert len(posts) == 3
     
-    # Each post should have variants
+    # Each post should have variants for all supported platforms
     for post in posts:
         assert 'variants' in post
         assert post['variants'] is not None
-        assert len(post['variants']) == 3
         assert 'instagram' in post['variants']
         assert 'facebook' in post['variants']
         assert 'linkedin' in post['variants']
-        # Each variant should be a string with content
-        assert isinstance(post['variants']['instagram'], str)
-        assert len(post['variants']['instagram']) > 0
+        assert 'twitter' in post['variants']
+        assert 'youtube' in post['variants']
+        insta_variant = post['variants']['instagram']
+        assert isinstance(insta_variant, dict)
+        assert len(insta_variant.get('text', '')) > 0
 
-def test_generate_posts_single_platform_no_variants():
-    """Test that posts don't include variants for single platform"""
+def test_generate_posts_single_platform_includes_variants():
+    """Even single-platform plans should include cross-platform variants"""
     posts = generate_posts(
         days=1,
         start_day=date(2025, 1, 1),
@@ -63,5 +64,6 @@ def test_generate_posts_single_platform_no_variants():
     # Should have 1 post
     assert len(posts) == 1
     
-    # Should not have variants (or variants is None) for single platform
-    assert posts[0].get('variants') is None
+    # Variants should still be present for downstream UI
+    assert isinstance(posts[0].get('variants'), dict)
+    assert 'instagram' in posts[0]['variants']

--- a/tests/test_platform_rules.py
+++ b/tests/test_platform_rules.py
@@ -1,0 +1,36 @@
+from platform_rules import apply_platform_rules, DEFAULT_VARIANT_PLATFORMS
+
+
+def test_rule_enforcement_truncates_long_copy():
+    body = "This is an intentionally long line of copy " * 20
+    payload = apply_platform_rules(
+        body=body,
+        platform='twitter',
+        hashtags=[f"tag{i}" for i in range(6)],
+        pillar_name='Story',
+        goals=['engagement'],
+        company='Test Co'
+    )
+
+    assert len(payload['text']) <= 260
+    assert any('Trimmed copy' in note for note in payload['warnings'])
+    assert len(payload['hashtags']) <= 3
+
+
+def test_instagram_hashtag_limit_snapshot():
+    body = "Concise caption with plenty of detail for the platform"
+    payload = apply_platform_rules(
+        body=body,
+        platform='instagram',
+        hashtags=[f"custom{i}" for i in range(20)],
+        pillar_name='Engagement',
+        goals=['comments']
+    )
+
+    assert payload['hashtags'] == [f"#custom{i}" for i in range(12)]
+    assert 'Trimmed hashtags' in ' '.join(payload.get('warnings', []))
+
+
+def test_default_platform_list_exposes_all_targets():
+    assert 'twitter' in DEFAULT_VARIANT_PLATFORMS
+    assert 'youtube' in DEFAULT_VARIANT_PLATFORMS


### PR DESCRIPTION
## Summary
- add shared platform rules for length, hashtags, CTAs, and thumbnails, and apply them when generating variants
- surface platform-tailored variants in the dashboard with copy/export controls and warning badges
- extend variant API coverage and add tests for rule enforcement and truncation heuristics

## Testing
- pytest tests/test_generator.py tests/test_generate_variants.py tests/test_platform_rules.py
- pytest tests/test_generator_full_post.py tests/test_generator_unit.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112eb3214832893760902d28b9ae0)