### PR TITLE
Add voice profile onboarding, coach UI, and drift guardrails

### DIFF
--- a/app.py
+++ b/app.py
@@ -2071,19 +2071,31 @@ def api_get_profile():
 
 def _persist_voice_profile(pid: str, samples: list[str], voice_blob: dict):
     db = get_db()
-    row = db.execute('SELECT details FROM profiles WHERE id = ?', (pid,)).fetchone()
-    base_details = _deserialize_json(row['details'], {}) if row else {}
-    if not isinstance(base_details, dict):
-        base_details = {}
-    merged_details = dict(base_details)
-    merged_details['voice_samples'] = samples
-    merged_details['voice_profile'] = voice_blob
-    db.execute(
-        '''INSERT INTO profiles (id, details)
-           VALUES (?, ?)
-           ON CONFLICT(id) DO UPDATE SET details=excluded.details''',
-        (pid, json.dumps(merged_details))
-    )
+    # Check if the profile exists
+    row = db.execute('SELECT * FROM profiles WHERE id = ?', (pid,)).fetchone()
+    if row:
+        base_details = _deserialize_json(row['details'], {}) if row['details'] else {}
+        if not isinstance(base_details, dict):
+            base_details = {}
+        merged_details = dict(base_details)
+        merged_details['voice_samples'] = samples
+        merged_details['voice_profile'] = voice_blob
+        db.execute(
+            'UPDATE profiles SET details = ? WHERE id = ?',
+            (json.dumps(merged_details), pid)
+        )
+    else:
+        # Insert a new profile row with at least required columns
+        merged_details = {
+            'voice_samples': samples,
+            'voice_profile': voice_blob
+        }
+        # Set sensible defaults for required columns
+        created_at = datetime.utcnow().isoformat()
+        db.execute(
+            'INSERT INTO profiles (id, details, created_at) VALUES (?, ?, ?)',
+            (pid, json.dumps(merged_details), created_at)
+        )
     db.commit()
 
 

--- a/app.py
+++ b/app.py
@@ -2125,7 +2125,7 @@ def api_save_voice_profile():
         return jsonify({'ok': False, 'error': 'Provide between 5 and 10 recent posts to train your voice.'}), 400
     voice_blob = voice_profile.profile_from_samples(cleaned)
     if not voice_blob:
-        return jsonify({'ok': False, 'error': 'Unable to read those samples. Please try again.'}), 400
+        return jsonify({'ok': False, 'error': 'Samples must contain text. Please provide valid post content.'}), 400
     _persist_voice_profile(pid, cleaned, voice_blob)
     return jsonify({'ok': True, 'voice_profile': voice_blob, 'samples': cleaned})
 

--- a/app.py
+++ b/app.py
@@ -2120,9 +2120,17 @@ def api_save_voice_profile():
     data = request.get_json(force=True) or {}
     samples = data.get('samples') if isinstance(data.get('samples'), list) else []
     cleaned = [str(s).strip() for s in samples if isinstance(s, str) and str(s).strip()]
-    cleaned = [s for s in cleaned if len(s) >= 8]
+    
+    # Validate initial sample count before filtering
     if len(cleaned) < 5 or len(cleaned) > 10:
         return jsonify({'ok': False, 'error': 'Provide between 5 and 10 recent posts to train your voice.'}), 400
+    
+    # Filter out samples that are too short (< 8 characters)
+    cleaned = [s for s in cleaned if len(s) >= 8]
+    
+    # Validate final sample count after filtering
+    if len(cleaned) < 5 or len(cleaned) > 10:
+        return jsonify({'ok': False, 'error': 'After removing very short posts, only {} valid samples remain. Please provide longer posts (at least 8 characters each).'.format(len(cleaned))}), 400
     voice_blob = voice_profile.profile_from_samples(cleaned)
     if not voice_blob:
         return jsonify({'ok': False, 'error': 'Samples must contain text. Please provide valid post content.'}), 400

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from datetime import timedelta
 from flask import Flask, request, jsonify, render_template, g, session, redirect, has_app_context, url_for
 import logging
+import voice_profile
 import threading
 import time
 import math
@@ -349,10 +350,18 @@ def _generate_posts_via_openai(spec: dict):
         start_day = payload.get('start_day')
         if isinstance(start_day, date):
             payload['start_day'] = start_day.isoformat()
+        voice_profile_ctx = payload.get('voice_profile') or None
         prompt = {
             'instruction': 'Create social media posts as structured JSON.',
             'requirements': payload
         }
+        if voice_profile_ctx:
+            prompt['voice_profile'] = {
+                'include_phrases': voice_profile_ctx.get('include_phrases'),
+                'avoid_phrases': voice_profile_ctx.get('avoid_phrases'),
+                'examples': voice_profile_ctx.get('example_lines'),
+                'avg_length': voice_profile_ctx.get('avg_length'),
+            }
         response = openai_client.chat.completions.create(  # type: ignore[attr-defined]
             model=OPENAI_GENERATE_MODEL,
             messages=[
@@ -420,6 +429,20 @@ def _generate_posts_from_image(spec: dict):
         return _parse_posts_payload(content)
     except Exception:
         return None
+
+
+def _apply_voice_guardrails(posts: list[dict], voice_profile_ctx: Optional[dict]):
+    if not voice_profile_ctx or not isinstance(posts, list):
+        return
+    for post in posts:
+        if not isinstance(post, dict):
+            continue
+        caption = post.get('caption') or ''
+        assessment = voice_profile.assess_text(voice_profile_ctx, caption)
+        post['voice_match_score'] = assessment['score']
+        if assessment.get('drift'):
+            post['voice_guardrail'] = assessment.get('message')
+            post['voice_suggestions'] = assessment.get('suggestions')
 
 class _PgConnectionWrapper:
     """Lightweight wrapper to normalize Postgres connection to sqlite-style API."""
@@ -1720,6 +1743,18 @@ def _profile_row_to_dict(row):
     }
 
 
+def _extract_voice_profile(details: Optional[dict]) -> Optional[dict]:
+    if not isinstance(details, dict):
+        return None
+    vp = details.get('voice_profile')
+    return vp if isinstance(vp, dict) else None
+
+
+def _active_voice_profile() -> Optional[dict]:
+    profile = _get_active_profile_dict() or {}
+    return _extract_voice_profile(profile.get('details') if isinstance(profile, dict) else {})
+
+
 def _get_active_profile_dict():
     """Return the current profile (if any) as a plain dict."""
     pid = session.get('user_id') or session.get('profile_id')
@@ -1994,6 +2029,7 @@ def _merge_generation_payload(payload: dict, profile: Optional[dict]) -> dict:
         'goals': _coerce_str_list(payload.get('goals'), profile.get('goals') or []),
         'include_images': bool(include_images),
         'details': details,
+        'voice_profile': _extract_voice_profile(details),
         'company': _normalize_company(company),
     }
     image_context = (payload.get('image_context') or '').strip()
@@ -2010,6 +2046,55 @@ def api_get_profile():
     if not row:
         return jsonify({'id': pid})
     return jsonify(_profile_row_to_dict(row))
+
+
+def _persist_voice_profile(pid: str, samples: list[str], voice_blob: dict):
+    db = get_db()
+    row = db.execute('SELECT details FROM profiles WHERE id = ?', (pid,)).fetchone()
+    base_details = _deserialize_json(row['details'], {}) if row else {}
+    if not isinstance(base_details, dict):
+        base_details = {}
+    merged_details = dict(base_details)
+    merged_details['voice_samples'] = samples
+    merged_details['voice_profile'] = voice_blob
+    db.execute(
+        '''INSERT INTO profiles (id, details)
+           VALUES (?, ?)
+           ON CONFLICT(id) DO UPDATE SET details=excluded.details''',
+        (pid, json.dumps(merged_details))
+    )
+    db.commit()
+
+
+@app.get('/api/voice-profile')
+def api_voice_profile():
+    pid = _ensure_profile_id()
+    profile = _get_active_profile_dict() or {}
+    details = profile.get('details') if isinstance(profile, dict) else {}
+    vp = _extract_voice_profile(details)
+    samples = details.get('voice_samples') if isinstance(details, dict) else None
+    return jsonify({
+        'ok': True,
+        'id': pid,
+        'voice_profile': vp,
+        'samples': samples if isinstance(samples, list) else [],
+    })
+
+
+@app.post('/api/voice-profile')
+def api_save_voice_profile():
+    pid = _ensure_profile_id()
+    data = request.get_json(force=True) or {}
+    samples = data.get('samples') if isinstance(data.get('samples'), list) else []
+    cleaned = [str(s).strip() for s in samples if isinstance(s, str) and str(s).strip()]
+    cleaned = [s for s in cleaned if len(s) >= 8]
+    if len(cleaned) < 5 or len(cleaned) > 10:
+        return jsonify({'ok': False, 'error': 'Provide between 5 and 10 recent posts to train your voice.'}), 400
+    voice_blob = voice_profile.profile_from_samples(cleaned)
+    if not voice_blob:
+        return jsonify({'ok': False, 'error': 'Unable to read those samples. Please try again.'}), 400
+    _persist_voice_profile(pid, cleaned, voice_blob)
+    return jsonify({'ok': True, 'voice_profile': voice_blob, 'samples': cleaned})
 
 
 @app.post('/api/profile')
@@ -2056,6 +2141,13 @@ def api_save_profile():
         details.setdefault('_content_version', content_version)
 
     db = get_db()
+    existing_row = db.execute('SELECT details FROM profiles WHERE id = ?', (pid,)).fetchone()
+    if existing_row:
+        existing_details = _deserialize_json(existing_row['details'], {}) if existing_row else {}
+        if isinstance(existing_details, dict):
+            for key, val in existing_details.items():
+                if key.startswith('voice_') and key not in details:
+                    details[key] = val
     db.execute(
         '''INSERT INTO profiles (id, industry, tone, platforms, brand_keywords, niche_keywords, goals, company, include_images, details)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -2354,10 +2446,13 @@ def api_generate():
                 niche_keywords=generation['niche_keywords'],
                 goals=generation['goals'],
                 details=generation['details'],
-                company=generation['company']
+                company=generation['company'],
+                voice_profile=generation.get('voice_profile')
             )
         except Exception:
             return jsonify({'ok': False, 'error': 'Failed to generate content'}), 500
+
+    _apply_voice_guardrails(posts, generation.get('voice_profile') or _active_voice_profile())
 
     if days == 1 and user_row and uid and not is_paid and not free_sample_used:
         _mark_free_sample_used(uid)

--- a/app.py
+++ b/app.py
@@ -2091,7 +2091,7 @@ def _persist_voice_profile(pid: str, samples: list[str], voice_blob: dict):
             'voice_profile': voice_blob
         }
         # Set sensible defaults for required columns
-        created_at = datetime.utcnow().isoformat()
+        created_at = datetime.now(timezone.utc).isoformat()
         db.execute(
             'INSERT INTO profiles (id, details, created_at) VALUES (?, ?, ?)',
             (pid, json.dumps(merged_details), created_at)

--- a/app.py
+++ b/app.py
@@ -2132,7 +2132,7 @@ def api_save_voice_profile():
     cleaned = [s for s in cleaned if len(s) >= VOICE_SAMPLE_MIN_LEN]
     
     # Validate final sample count after filtering
-    if len(cleaned) < VOICE_SAMPLE_MIN_COUNT or len(cleaned) > VOICE_SAMPLE_MAX_COUNT:
+    if len(cleaned) < VOICE_SAMPLE_MIN_COUNT:
         return jsonify({'ok': False, 'error': f'After removing very short posts, only {len(cleaned)} valid samples remain. Please provide longer posts (at least {VOICE_SAMPLE_MIN_LEN} characters each).'}), 400
     voice_blob = voice_profile.profile_from_samples(cleaned)
     if not voice_blob:

--- a/app.py
+++ b/app.py
@@ -389,6 +389,7 @@ def _generate_posts_from_image(spec: dict):
             payload['start_day'] = start_day.isoformat()
         # keep context separate so we can emphasize it in the prompt
         image_context = (payload.get('image_context') or '').strip()
+        voice_profile_ctx = payload.get('voice_profile') or None
         requirements = {
             'days': payload.get('days'),
             'platforms': payload.get('platforms'),
@@ -400,11 +401,31 @@ def _generate_posts_from_image(spec: dict):
             'details': payload.get('details'),
             'start_day': payload.get('start_day'),
         }
+        if voice_profile_ctx:
+            requirements['voice_profile'] = {
+                'include_phrases': voice_profile_ctx.get('include_phrases'),
+                'avoid_phrases': voice_profile_ctx.get('avoid_phrases'),
+                'examples': voice_profile_ctx.get('example_lines'),
+                'avg_length': voice_profile_ctx.get('avg_length'),
+            }
         instructions = [
             "Look at the attached inspiration image and craft polished social posts that reference what you see.",
             "Blend the visual cues with the requirements JSON below.",
             "Respond with ONLY a JSON array of post objects (same schema as other generation responses).",
         ]
+        if voice_profile_ctx:
+            include = voice_profile_ctx.get('include_phrases') or []
+            avoid = voice_profile_ctx.get('avoid_phrases') or []
+            examples = voice_profile_ctx.get('example_lines') or []
+            voice_hints = []
+            if include:
+                voice_hints.append(f"Use phrases like: {', '.join(include[:3])}.")
+            if avoid:
+                voice_hints.append(f"Avoid overusing: {', '.join(avoid[:3])}.")
+            if examples:
+                voice_hints.append(f"Match cadence: {examples[0][:140]}")
+            if voice_hints:
+                instructions.append("Voice profile: " + " ".join(voice_hints))
         if image_context:
             instructions.insert(1, f"Emphasize this guidance from the user: {image_context.strip()[:500]}")
         user_content = [

--- a/app.py
+++ b/app.py
@@ -41,6 +41,9 @@ except Exception:
 
 IMAGE_DATA_URL_MAX_BYTES = 2_500_000  # ~2.5MB encoded payload cap for inline uploads
 MAX_FEEDBACK_NOTE_LEN = 1500
+VOICE_SAMPLE_MIN_LEN = 8  # Minimum character length for voice profile samples
+VOICE_SAMPLE_MIN_COUNT = 5  # Minimum number of samples required
+VOICE_SAMPLE_MAX_COUNT = 10  # Maximum number of samples allowed
 try:
     TEAM_MEMBER_LIMIT = int(os.getenv('TEAM_MEMBER_LIMIT', '10'))
 except (TypeError, ValueError):
@@ -2122,15 +2125,15 @@ def api_save_voice_profile():
     cleaned = [str(s).strip() for s in samples if isinstance(s, str) and str(s).strip()]
     
     # Validate initial sample count before filtering
-    if len(cleaned) < 5 or len(cleaned) > 10:
-        return jsonify({'ok': False, 'error': 'Provide between 5 and 10 recent posts to train your voice.'}), 400
+    if len(cleaned) < VOICE_SAMPLE_MIN_COUNT or len(cleaned) > VOICE_SAMPLE_MAX_COUNT:
+        return jsonify({'ok': False, 'error': f'Provide between {VOICE_SAMPLE_MIN_COUNT} and {VOICE_SAMPLE_MAX_COUNT} recent posts to train your voice.'}), 400
     
-    # Filter out samples that are too short (< 8 characters)
-    cleaned = [s for s in cleaned if len(s) >= 8]
+    # Filter out samples that are too short
+    cleaned = [s for s in cleaned if len(s) >= VOICE_SAMPLE_MIN_LEN]
     
     # Validate final sample count after filtering
-    if len(cleaned) < 5 or len(cleaned) > 10:
-        return jsonify({'ok': False, 'error': 'After removing very short posts, only {} valid samples remain. Please provide longer posts (at least 8 characters each).'.format(len(cleaned))}), 400
+    if len(cleaned) < VOICE_SAMPLE_MIN_COUNT or len(cleaned) > VOICE_SAMPLE_MAX_COUNT:
+        return jsonify({'ok': False, 'error': f'After removing very short posts, only {len(cleaned)} valid samples remain. Please provide longer posts (at least {VOICE_SAMPLE_MIN_LEN} characters each).'}), 400
     voice_blob = voice_profile.profile_from_samples(cleaned)
     if not voice_blob:
         return jsonify({'ok': False, 'error': 'Samples must contain text. Please provide valid post content.'}), 400

--- a/app.py
+++ b/app.py
@@ -2120,9 +2120,15 @@ def api_save_voice_profile():
     data = request.get_json(force=True) or {}
     samples = data.get('samples') if isinstance(data.get('samples'), list) else []
     cleaned = [str(s).strip() for s in samples if isinstance(s, str) and str(s).strip()]
-    cleaned = [s for s in cleaned if len(s) >= 8]
+    # Enforce minimum and maximum sample length per sample.
+    cleaned = [
+        s for s in cleaned
+        if VOICE_SAMPLE_MIN_LEN <= len(s) <= VOICE_SAMPLE_MAX_LEN
+    ]
     if len(cleaned) < 5 or len(cleaned) > 10:
-        return jsonify({'ok': False, 'error': 'Provide between 5 and 10 recent posts to train your voice.'}), 400
+        return jsonify({'ok': False, 'error': f'Provide between 5 and 10 recent posts to train your voice. Each post must be {VOICE_SAMPLE_MIN_LEN}-{VOICE_SAMPLE_MAX_LEN} characters.'}), 400
+    if len(cleaned) != len(samples):
+        return jsonify({'ok': False, 'error': f'Each post must be {VOICE_SAMPLE_MIN_LEN}-{VOICE_SAMPLE_MAX_LEN} characters.'}), 400
     voice_blob = voice_profile.profile_from_samples(cleaned)
     if not voice_blob:
         return jsonify({'ok': False, 'error': 'Samples must contain text. Please provide valid post content.'}), 400

--- a/generator.py
+++ b/generator.py
@@ -210,18 +210,31 @@ def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
 
     company_line = f"From {company}." if company else ""
     theme_line = f"Theme: {theme}." if theme else ""
-    body = (
-        f"{pillar_name} • {industry}{brand_line}\n"
-        f"{pillar_hint}\n\n"
-        f"{company_line}\n"
-        f"{theme_line}\n"
-        f"{goal_line}\n"
-        f"Tone: {tone_blurb}\n"
-        f"{voice_hint}\n"
-        f"{signature_example}\n"
-        f"Platform tip: {platform_hint}\n\n"
-        f"CTA: Tell us what you think below 👇"
-    )
+    
+    # Build body, only including non-empty lines
+    lines = [
+        f"{pillar_name} • {industry}{brand_line}",
+        pillar_hint,
+        ""  # blank line
+    ]
+    if company_line:
+        lines.append(company_line)
+    if theme_line:
+        lines.append(theme_line)
+    if goal_line:
+        lines.append(goal_line)
+    lines.append(f"Tone: {tone_blurb}")
+    if voice_hint:
+        lines.append(voice_hint)
+    if signature_example:
+        lines.append(signature_example)
+    lines.extend([
+        f"Platform tip: {platform_hint}",
+        "",  # blank line
+        "CTA: Tell us what you think below 👇"
+    ])
+    
+    body = "\n".join(lines)
 
     tags = " ".join(hashtags)
     return f"{body}\n\n{tags}"

--- a/generator.py
+++ b/generator.py
@@ -653,7 +653,8 @@ def generate_posts(
     niche_keywords = list(niche_keywords or [])
     goals = list(goals or [])
     details = dict(details or {})
-    voice_profile = dict(voice_profile or details.get('voice_profile') or {}) if isinstance(voice_profile or details.get('voice_profile'), Mapping) else {}
+    voice_profile = voice_profile or details.get('voice_profile') or {}
+    voice_profile = dict(voice_profile) if isinstance(voice_profile, Mapping) else {}
     company = company or ""
 
     posts: list[dict[str, Any]] = []

--- a/generator.py
+++ b/generator.py
@@ -186,7 +186,7 @@ def to_sentence_case(s: str):
     return s[0].upper() + s[1:]
 
 def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
-                 platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str], company: str = "", theme: Optional[str] = None):
+                 platform: str, brand_keywords: list[str], hashtags: list[str], goals: list[str], company: str = "", theme: Optional[str] = None, voice_profile: Optional[dict] = None):
     tone_blurb = {
         "friendly": "Warm, encouraging, and conversational.",
         "professional": "Clear, confident, and value-focused.",
@@ -198,6 +198,16 @@ def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
     brand_line = f" ({', '.join(brand_keywords)})" if brand_keywords else ""
     goal_line = f"Focus: {', '.join(goals)}." if goals else ""
 
+    voice_hint = ""
+    signature_example = ""
+    if isinstance(voice_profile, dict):
+        phrases = voice_profile.get('include_phrases') or []
+        if phrases:
+            voice_hint = f"Voice: weave in {', '.join(list(phrases)[:3])}."
+        examples = voice_profile.get('example_lines') or []
+        if examples:
+            signature_example = f"Example cadence: {examples[0][:120]}"
+
     company_line = f"From {company}." if company else ""
     theme_line = f"Theme: {theme}." if theme else ""
     body = (
@@ -207,6 +217,8 @@ def make_caption(industry: str, tone: str, pillar_name: str, pillar_hint: str,
         f"{theme_line}\n"
         f"{goal_line}\n"
         f"Tone: {tone_blurb}\n"
+        f"{voice_hint}\n"
+        f"{signature_example}\n"
         f"Platform tip: {platform_hint}\n\n"
         f"CTA: Tell us what you think below 👇"
     )
@@ -608,6 +620,7 @@ def generate_posts(
     goals: Optional[list[str]] = None,
     company: str = "",
     details: Optional[Mapping[str, Any]] = None,
+    voice_profile: Optional[Mapping[str, Any]] = None,
 ) -> list[dict[str, Any]]:
     """Generate a list of posts for the requested period.
 
@@ -640,6 +653,7 @@ def generate_posts(
     niche_keywords = list(niche_keywords or [])
     goals = list(goals or [])
     details = dict(details or {})
+    voice_profile = dict(voice_profile or details.get('voice_profile') or {}) if isinstance(voice_profile or details.get('voice_profile'), Mapping) else {}
     company = company or ""
 
     posts: list[dict[str, Any]] = []
@@ -663,7 +677,8 @@ def generate_posts(
                 hashtags=hashtags,
                 goals=goals,
                 company=company,
-                theme=details.get("note")
+                theme=details.get("note"),
+                voice_profile=voice_profile
             )
             variants[p] = caption
 

--- a/static/app.js
+++ b/static/app.js
@@ -2124,7 +2124,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // Floating Action Button functionality - REMOVED: All generation now happens on /generate dashboard
 
 // Review Insights functionality
-document.addEventListener('DOMContentLoaded', () => {
+function initReviewInsights() {
   const toggleBtn = document.getElementById('toggle-review-insights');
   const reviewSection = document.getElementById('review-insights-section');
   const reviewText = document.getElementById('review-text');
@@ -2196,7 +2196,7 @@ document.addEventListener('DOMContentLoaded', () => {
       reviewLoading.classList.add('hidden');
     }
   });
-});
+}
 
 
 
@@ -2232,7 +2232,8 @@ function parseWizardSamples(raw = '') {
     .filter(Boolean);
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+// Wizard Voice Profile functionality
+function initWizardVoiceProfile() {
   const btn = document.getElementById('wizard-train-voice');
   const input = document.getElementById('wizard-voice-samples');
   const toast = document.getElementById('wizard-voice-toast');
@@ -2269,4 +2270,10 @@ document.addEventListener('DOMContentLoaded', () => {
       btn.textContent = 'Save voice samples';
     }
   });
+}
+
+// Consolidated DOMContentLoaded handler
+document.addEventListener('DOMContentLoaded', () => {
+  initReviewInsights();
+  initWizardVoiceProfile();
 });

--- a/static/app.js
+++ b/static/app.js
@@ -2199,3 +2199,74 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
+
+async function hydrateWizardVoicePanel() {
+  const status = document.getElementById('wizard-voice-status');
+  const helper = document.getElementById('wizard-voice-helper');
+  const toast = document.getElementById('wizard-voice-toast');
+  if (toast) toast.textContent = '';
+  try {
+    const res = await fetch('/api/voice-profile', { credentials: 'include' });
+    if (!res.ok) return;
+    const data = await res.json();
+    const vp = data.voice_profile || null;
+    const sampleCount = Array.isArray(data.samples) ? data.samples.length : 0;
+    if (status) {
+      status.textContent = vp ? `Trained • ${sampleCount} samples` : 'Optional';
+      status.className = vp
+        ? 'px-2 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700'
+        : 'px-2 py-1 rounded-full text-xs font-medium bg-purple-50 text-purple-700';
+    }
+    if (helper && vp) {
+      helper.textContent = 'We’ll keep tone, cadence, and vocab synced with these samples.';
+    }
+  } catch (err) {
+    console.error('Wizard voice panel fetch failed', err);
+  }
+}
+
+function parseWizardSamples(raw = '') {
+  return (raw || '')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('wizard-train-voice');
+  const input = document.getElementById('wizard-voice-samples');
+  const toast = document.getElementById('wizard-voice-toast');
+  if (!btn || !input) return;
+
+  hydrateWizardVoicePanel();
+
+  btn.addEventListener('click', async () => {
+    const samples = parseWizardSamples(input.value || '');
+    if (samples.length < 5 || samples.length > 10) {
+      if (toast) toast.textContent = 'Add between 5 and 10 posts so we can map your voice.';
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = 'Saving…';
+    try {
+      const res = await fetch('/api/voice-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ samples })
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.ok) {
+        throw new Error(data.error || 'Unable to save samples');
+      }
+      if (toast) toast.textContent = 'Voice saved. Future plans will use this cadence.';
+      hydrateWizardVoicePanel();
+    } catch (err) {
+      console.error('Wizard voice training failed', err);
+      if (toast) toast.textContent = 'Could not save samples right now.';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Save voice samples';
+    }
+  });
+});

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -23,7 +23,6 @@ const platformPresetState = {
 };
 const DEFAULT_GENERATOR_PLATFORM = 'instagram';
 const VIDEO_PLATFORM_KEYS = new Set(['instagram', 'short_video', 'tiktok']);
-const voiceCoachState = { profile: null, samples: [] };
 
 async function getDashboardConfig() {
   if (dashboardConfigCache) return dashboardConfigCache;

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -23,6 +23,7 @@ const platformPresetState = {
 };
 const DEFAULT_GENERATOR_PLATFORM = 'instagram';
 const VIDEO_PLATFORM_KEYS = new Set(['instagram', 'short_video', 'tiktok']);
+const voiceCoachState = { profile: null, samples: [] };
 
 async function getDashboardConfig() {
   if (dashboardConfigCache) return dashboardConfigCache;
@@ -118,6 +119,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Feedback form in sidebar
   setupFeedbackForm();
+
+  // Voice coach panel
+  setupVoiceCoach();
 
   hydrateVoiceSummary({});
   hydrateSeedPosts();
@@ -653,6 +657,97 @@ async function setupFeedbackForm() {
         submitBtn.disabled = false;
         submitBtn.textContent = 'Send to team';
       }
+    }
+  });
+}
+
+async function fetchVoiceCoachProfile() {
+  try {
+    const res = await fetch('/api/voice-profile', { credentials: 'include' });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch (err) {
+    console.error('voice profile fetch failed', err);
+    return null;
+  }
+}
+
+function renderVoiceCoachPanel(payload = {}) {
+  const status = document.getElementById('voice-coach-status');
+  const include = document.getElementById('voice-coach-include');
+  const avoid = document.getElementById('voice-coach-avoid');
+  const example = document.getElementById('voice-coach-example');
+  const toast = document.getElementById('voice-coach-toast');
+  if (toast) toast.textContent = '';
+  const vp = payload.voice_profile || payload.profile || null;
+  voiceCoachState.profile = vp;
+  voiceCoachState.samples = payload.samples || [];
+
+  if (status) {
+    const sampleCount = Array.isArray(payload.samples) ? payload.samples.length : 0;
+    status.textContent = vp ? `Trained • ${sampleCount} samples` : 'Not trained';
+    status.className = vp
+      ? 'px-2 py-1 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700'
+      : 'px-2 py-1 rounded-full text-xs font-medium bg-purple-50 text-purple-700';
+  }
+
+  if (include) {
+    const phrases = (vp?.include_phrases || []).slice(0, 3).join(', ');
+    include.textContent = phrases || 'Add samples to see your top phrases.';
+  }
+  if (avoid) {
+    const phrases = (vp?.avoid_phrases || []).slice(0, 3).join(', ');
+    avoid.textContent = phrases || 'We’ll flag repeated filler once trained.';
+  }
+  if (example) {
+    const line = (vp?.example_lines || [])[0];
+    example.textContent = line || 'Save samples to generate a reference line.';
+  }
+}
+
+function parseVoiceSamples(raw = '') {
+  return (raw || '')
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean);
+}
+
+async function setupVoiceCoach() {
+  const input = document.getElementById('voice-sample-input');
+  const btn = document.getElementById('save-voice-samples');
+  if (!input || !btn) return;
+
+  const data = await fetchVoiceCoachProfile();
+  if (data) renderVoiceCoachPanel(data);
+
+  btn.addEventListener('click', async () => {
+    const toast = document.getElementById('voice-coach-toast');
+    const samples = parseVoiceSamples(input.value || '');
+    if (samples.length < 5 || samples.length > 10) {
+      if (toast) toast.textContent = 'Add between 5 and 10 samples so we can train your voice.';
+      return;
+    }
+    btn.disabled = true;
+    btn.textContent = 'Training…';
+    try {
+      const res = await fetch('/api/voice-profile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ samples })
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error || 'Unable to save voice samples');
+      }
+      renderVoiceCoachPanel(body);
+      if (toast) toast.textContent = 'Voice updated—new generations will stay on-brand.';
+    } catch (error) {
+      console.error('voice coach save failed', error);
+      if (toast) toast.textContent = 'Could not train right now. Please try again.';
+    } finally {
+      btn.disabled = false;
+      btn.textContent = 'Train voice';
     }
   });
 }
@@ -1275,6 +1370,18 @@ function renderPostCard(post) {
   const editorId = `post-editor-${post.day_index}-${post.platform}-${Math.random().toString(36).slice(2,7)}`;
   const stampId = `${editorId}-stamp`;
   const variantsMarkup = post.variants ? renderPlatformVariants(post.variants, post.platform) : '';
+  const voiceScore = typeof post.voice_match_score === 'number' ? post.voice_match_score : null;
+  const guardrail = post.voice_guardrail || '';
+  const voiceSuggestions = Array.isArray(post.voice_suggestions) ? post.voice_suggestions : [];
+  const guardrailBlock = guardrail
+    ? `<div class="p-3 mb-3 bg-amber-50 border border-amber-200 rounded">
+        <p class="text-xs font-semibold text-amber-900">${escapeHtml(guardrail)}</p>
+        ${voiceSuggestions.map(s => `<p class="text-xs text-amber-800 mt-1">${escapeHtml(s)}</p>`).join('')}
+      </div>`
+    : '';
+  const voiceScoreBlock = voiceScore !== null
+    ? `<div class="text-xs text-slate-500 mb-1">Voice match: ${(voiceScore * 100).toFixed(0)}%</div>`
+    : '';
 
   // Check if this post has variants (multiple platforms)
   const hasVariants = post.variants && Object.keys(post.variants).length > 1;
@@ -1297,6 +1404,9 @@ function renderPostCard(post) {
     </div>
 
     ${post.image_url ? `<img class="w-full h-32 object-cover rounded mb-3" src="${post.image_url}" alt="Suggested image" />` : ''}
+
+    ${voiceScoreBlock}
+    ${guardrailBlock}
 
     <div class="text-xs text-slate-500 mb-2"><strong>Image prompt:</strong> ${escapeHtml(post.image_prompt)}</div>
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -474,6 +474,46 @@
         </div>
       </div>
 
+      <div class="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-slate-200" id="voice-coach">
+        <div class="flex items-start justify-between gap-3 mb-3">
+          <div>
+            <h4 class="text-lg font-semibold text-slate-900">Voice coach</h4>
+            <p class="text-sm text-slate-600">Upload 5–10 recent posts to lock cadence and vocab.</p>
+          </div>
+          <span class="px-2 py-1 rounded-full text-xs font-medium bg-purple-50 text-purple-700" id="voice-coach-status">Not trained</span>
+        </div>
+
+        <div class="mb-4 space-y-2 text-sm text-slate-700">
+          <div class="flex items-start gap-2">
+            <span class="text-purple-500">★</span>
+            <div>
+              <p class="font-semibold">Include more of:</p>
+              <p id="voice-coach-include" class="text-slate-600">Add samples to see your top phrases.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-2">
+            <span class="text-rose-500">⚑</span>
+            <div>
+              <p class="font-semibold">Avoid overusing:</p>
+              <p id="voice-coach-avoid" class="text-slate-600">We’ll flag repeated filler once trained.</p>
+            </div>
+          </div>
+          <div class="flex items-start gap-2">
+            <span class="text-emerald-500">➤</span>
+            <div>
+              <p class="font-semibold">On-brand example:</p>
+              <p id="voice-coach-example" class="text-slate-600">Save samples to generate a reference line.</p>
+            </div>
+          </div>
+        </div>
+
+        <label for="voice-sample-input" class="block text-sm font-medium text-slate-700 mb-2">Paste 5–10 recent posts</label>
+        <textarea id="voice-sample-input" class="w-full input text-sm mb-2" rows="5" placeholder="One post per line…"></textarea>
+        <p class="text-xs text-slate-500 mb-3">We only use these to match tone for this workspace. Retrain anytime.</p>
+        <button id="save-voice-samples" class="btn-primary w-full text-sm py-2 rounded-lg">Train voice</button>
+        <p id="voice-coach-toast" class="text-xs text-slate-600 mt-2"></p>
+      </div>
+
       <div class="bg-white/80 backdrop-blur-sm rounded-2xl p-6 shadow-lg border border-slate-200">
         <h4 class="text-lg font-semibold mb-2 text-slate-900">Feedback & requests</h4>
         <p class="text-sm text-slate-600 mb-4">Tell us what to polish next. We'll get it to the team.</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -323,6 +323,21 @@
           <div class="text-sm text-slate-500 mt-3">Content pack: <span id="modal-content-version">loading…</span></div>
         </div>
 
+        <div class="bg-white/80 backdrop-blur-sm rounded-2xl p-5 border border-slate-200 mb-4">
+          <div class="flex items-start justify-between gap-3 mb-2">
+            <div>
+              <p class="text-xs uppercase tracking-[0.3em] text-slate-400">Step 4</p>
+              <h4 class="text-lg font-semibold text-slate-900">Train your voice</h4>
+              <p class="text-sm text-slate-600">Paste 5–10 posts you’ve already published. We’ll mirror cadence, tone, and vocab.</p>
+            </div>
+            <span id="wizard-voice-status" class="px-2 py-1 rounded-full text-xs font-medium bg-purple-50 text-purple-700">Optional</span>
+          </div>
+          <textarea id="wizard-voice-samples" class="w-full input text-sm mb-2" rows="5" placeholder="One post per line"></textarea>
+          <p id="wizard-voice-helper" class="text-xs text-slate-500 mb-3">Between 5 and 10 samples works best. You can retrain anytime from Generate.</p>
+          <button id="wizard-train-voice" class="btn-primary w-full text-sm py-2 rounded-lg">Save voice samples</button>
+          <p id="wizard-voice-toast" class="text-xs text-slate-600 mt-2"></p>
+        </div>
+
         <!-- Generate Buttons - Prominent placement -->
         <div class="bg-gradient-to-r from-purple-50 to-blue-50 rounded-2xl p-6 border border-purple-100">
           <h4 class="text-lg font-semibold mb-4 text-slate-900 text-center">Ready to generate your content?</h4>

--- a/tests/test_openai_voice_prompt.py
+++ b/tests/test_openai_voice_prompt.py
@@ -1,0 +1,50 @@
+import app
+
+
+class _DummyCompletions:
+    def __init__(self):
+        self.kwargs = None
+
+    def create(self, **kwargs):
+        self.kwargs = kwargs
+        # minimal response structure consumed by _extract_choice_content
+        return type('Resp', (), {'choices': [{'message': {'content': '[]'}}]})
+
+
+class _DummyChat:
+    def __init__(self):
+        self.completions = _DummyCompletions()
+
+
+class _DummyClient:
+    def __init__(self):
+        self.chat = _DummyChat()
+
+
+def test_image_generation_prompt_includes_voice_profile(monkeypatch):
+    client = _DummyClient()
+    monkeypatch.setattr(app, 'openai_client', client)
+    monkeypatch.setattr(app, 'USE_OPENAI', True)
+
+    spec = {
+        'image_data_url': 'data:image/png;base64,abc123',
+        'platforms': ['instagram'],
+        'tone': 'friendly',
+        'industry': 'Fitness',
+        'company': 'Acme Fit',
+        'brand_keywords': ['coaching'],
+        'voice_profile': {
+            'include_phrases': ['let’s move', 'we got you'],
+            'avoid_phrases': ['synergy'],
+            'example_lines': ['We got you—small steps daily add up.'],
+            'avg_length': 24.5,
+        }
+    }
+
+    app._generate_posts_from_image(spec)
+    text_block = client.chat.completions.kwargs['messages'][1]['content'][0]['text']
+
+    assert 'voice profile' in text_block.lower()
+    assert 'include_phrases' in text_block
+    assert 'avoid_phrases' in text_block
+    assert 'examples' in text_block

--- a/tests/test_voice_profile.py
+++ b/tests/test_voice_profile.py
@@ -1,0 +1,51 @@
+import voice_profile
+
+
+def test_profile_from_samples_builds_embedding():
+    samples = [
+        "We love celebrating small wins with our crew.",
+        "Friendly reminder: book your session early and bring questions!",
+        "We keep posts punchy, helpful, and always invite replies.",
+        "Your ideas drive our roadmap—drop them below.",
+        "Morning cadence, warm tone, and plenty of encouragement."
+    ]
+    profile = voice_profile.profile_from_samples(samples)
+    assert profile['sample_count'] == len(samples)
+    assert 'embedding' in profile and profile['embedding']
+    assert 'include_phrases' in profile and profile['include_phrases']
+    assert profile['avg_length'] > 4
+
+
+def test_assess_text_flags_drift_and_messages():
+    samples = [
+        "We keep it warm, helpful, and upbeat—always inviting the reader in.",
+        "Remember: quick wins and friendly calls to action are our jam.",
+        "Short, encouraging lines make our posts feel human."
+    ]
+    profile = voice_profile.profile_from_samples(samples)
+    on_brand = "Quick win: share your first draft today—our team is cheering you on!"
+    off_brand = "Quarterly EBITDA results have been reconciled per the new compliance memo."
+
+    strong = voice_profile.assess_text(profile, on_brand, threshold=0.72)
+    drift = voice_profile.assess_text(profile, off_brand, threshold=0.72)
+
+    assert strong['score'] > drift['score']
+    assert drift['drift'] is True
+    assert drift['message']
+    assert any('phrase' in s.lower() for s in drift.get('suggestions', []))
+
+
+def test_evaluate_prompts_wraps_assessment():
+    samples = [
+        "We cheer on every customer milestone with short, kind notes.",
+        "Keep it encouraging and specific—no stiff jargon.",
+        "Punchy hooks, clear CTAs, plenty of gratitude."
+    ]
+    profile = voice_profile.profile_from_samples(samples)
+    prompts = [
+        "New drop: tag us when you try it!",
+        "This memorandum outlines our Q4 audit requirements."
+    ]
+    results = voice_profile.evaluate_prompts(profile, prompts, threshold=0.7)
+    assert len(results) == 2
+    assert results[1]['drift'] is True

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -1,0 +1,110 @@
+import math
+import re
+from collections import Counter
+from datetime import datetime
+from typing import Iterable, Mapping
+
+
+WORD_RE = re.compile(r"[a-zA-Z'][a-zA-Z']*")
+STOPWORDS = {
+    'the', 'and', 'a', 'to', 'of', 'in', 'for', 'on', 'with', 'is', 'it', 'this', 'that', 'at', 'by', 'an',
+    'be', 'are', 'as', 'from', 'or', 'we', 'you', 'your', 'our', 'us', 'about'
+}
+
+
+def _tokenize(text: str) -> list[str]:
+    if not text:
+        return []
+    return WORD_RE.findall(text.lower())
+
+
+def build_embedding(text: str) -> dict[str, float]:
+    tokens = _tokenize(text)
+    counts = Counter(tokens)
+    total = float(sum(counts.values()) or 1.0)
+    return {token: count / total for token, count in counts.items()}
+
+
+def merge_embeddings(embeddings: Iterable[Mapping[str, float]]) -> dict[str, float]:
+    accumulator: Counter[str] = Counter()
+    total = 0
+    for emb in embeddings:
+        for token, weight in (emb or {}).items():
+            accumulator[token] += float(weight)
+            total += float(weight)
+    if not total:
+        return {}
+    return {token: weight / total for token, weight in accumulator.items()}
+
+
+def cosine_similarity(a: Mapping[str, float], b: Mapping[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = 0.0
+    for token, aval in a.items():
+        bval = b.get(token)
+        if bval:
+            dot += float(aval) * float(bval)
+    a_norm = math.sqrt(sum(float(v) ** 2 for v in a.values()))
+    b_norm = math.sqrt(sum(float(v) ** 2 for v in b.values()))
+    if not a_norm or not b_norm:
+        return 0.0
+    return dot / (a_norm * b_norm)
+
+
+def _top_phrases(tokens: list[str], n: int = 5) -> list[str]:
+    counts = Counter([t for t in tokens if t not in STOPWORDS])
+    return [token for token, _ in counts.most_common(n)]
+
+
+def profile_from_samples(samples: list[str]) -> dict:
+    cleaned = [s.strip() for s in samples if isinstance(s, str) and s.strip()]
+    if not cleaned:
+        return {}
+    embeddings = [build_embedding(text) for text in cleaned]
+    merged = merge_embeddings(embeddings)
+    tokens: list[str] = []
+    for text in cleaned:
+        tokens.extend(_tokenize(text))
+    include_phrases = _top_phrases(tokens, 7)
+    avoid_phrases = [t for t in include_phrases if len(t) <= 3][:3]
+    avg_length = sum(len(text.split()) for text in cleaned) / len(cleaned)
+    example_lines = cleaned[:3]
+    return {
+        'created_at': datetime.utcnow().isoformat() + 'Z',
+        'sample_count': len(cleaned),
+        'avg_length': round(avg_length, 2),
+        'include_phrases': include_phrases,
+        'avoid_phrases': avoid_phrases,
+        'example_lines': example_lines,
+        'embedding': merged,
+    }
+
+
+def assess_text(profile: Mapping[str, object], text: str, *, threshold: float = 0.72) -> dict:
+    embedding = profile.get('embedding') if isinstance(profile, Mapping) else None
+    score = cosine_similarity(embedding or {}, build_embedding(text))
+    include_phrases = list(profile.get('include_phrases') or []) if isinstance(profile, Mapping) else []
+    suggestions = []
+    if include_phrases:
+        suggestions.append(f"Lean on phrases like: {', '.join(include_phrases[:3])}.")
+    avoid_phrases = list(profile.get('avoid_phrases') or []) if isinstance(profile, Mapping) else []
+    if avoid_phrases:
+        suggestions.append(f"Avoid overusing: {', '.join(avoid_phrases[:2])}.")
+    drift = score < threshold
+    message = None
+    if drift:
+        message = "Closer to your voice: tighten cadence and reuse your go-to phrases."
+    return {
+        'score': round(score, 4),
+        'drift': drift,
+        'message': message,
+        'suggestions': suggestions
+    }
+
+
+def evaluate_prompts(profile: Mapping[str, object], prompts: list[str], *, threshold: float = 0.72) -> list[dict]:
+    results = []
+    for text in prompts:
+        results.append(assess_text(profile, text, threshold=threshold))
+    return results

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -104,7 +104,36 @@ def assess_text(profile: Mapping[str, object], text: str, *, threshold: float = 
 
 
 def evaluate_prompts(profile: Mapping[str, object], prompts: list[str], *, threshold: float = 0.72) -> list[dict]:
+    if not prompts:
+        return []
+    
+    # Batch build embeddings for all prompts upfront to avoid redundant work
+    prompt_embeddings = [build_embedding(text) for text in prompts]
+    
+    # Extract profile data once
+    profile_embedding = profile.get('embedding') if isinstance(profile, Mapping) else None
+    include_phrases = list(profile.get('include_phrases') or []) if isinstance(profile, Mapping) else []
+    avoid_phrases = list(profile.get('avoid_phrases') or []) if isinstance(profile, Mapping) else []
+    
+    # Build suggestions once since they're the same for all prompts
+    suggestions = []
+    if include_phrases:
+        suggestions.append(f"Lean on phrases like: {', '.join(include_phrases[:3])}.")
+    if avoid_phrases:
+        suggestions.append(f"Avoid overusing: {', '.join(avoid_phrases[:2])}.")
+    
     results = []
-    for text in prompts:
-        results.append(assess_text(profile, text, threshold=threshold))
+    for text_embedding in prompt_embeddings:
+        score = cosine_similarity(profile_embedding or {}, text_embedding)
+        drift = score < threshold
+        message = None
+        if drift:
+            message = "Closer to your voice: tighten cadence and reuse your go-to phrases."
+        results.append({
+            'score': round(score, 4),
+            'drift': drift,
+            'message': message,
+            'suggestions': suggestions
+        })
+    
     return results

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -58,6 +58,42 @@ def _top_phrases(tokens: list[str], n: int = 5) -> list[str]:
 
 
 def profile_from_samples(samples: list[str]) -> dict:
+    """Build a voice profile from a collection of sample text strings.
+
+    Analyzes the provided samples to extract linguistic patterns, common phrases,
+    and stylistic characteristics that define a unique "voice". The resulting profile
+    can be used to assess whether new content aligns with the established voice.
+
+    Args:
+        samples: A list of text strings representing the voice to profile. Each sample
+                should be a complete post, message, or content snippet that exemplifies
+                the desired tone and style. Empty or whitespace-only strings are ignored.
+
+    Returns:
+        A dictionary containing the voice profile with the following structure:
+        {
+            'created_at': str,           # ISO 8601 timestamp (UTC) when profile was created
+            'sample_count': int,         # Number of valid samples analyzed
+            'avg_length': float,         # Average word count across all samples
+            'include_phrases': list[str], # Top 7 most frequent non-stopword tokens
+            'avoid_phrases': list[str],  # Up to 3 short (≤3 chars) frequent tokens to avoid overusing
+            'example_lines': list[str],  # First 3 sample texts for reference
+            'embedding': dict[str, float] # Merged token frequency embeddings (token → normalized weight)
+        }
+        
+        Returns an empty dict if no valid samples are provided.
+
+    Example:
+        >>> samples = [
+        ...     "We love celebrating small wins with our crew.",
+        ...     "Friendly reminder: book your session early!",
+        ... ]
+        >>> profile = profile_from_samples(samples)
+        >>> profile['sample_count']
+        2
+        >>> 'embedding' in profile
+        True
+    """
     cleaned = [s.strip() for s in samples if isinstance(s, str) and s.strip()]
     if not cleaned:
         return {}

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -82,6 +82,28 @@ def profile_from_samples(samples: list[str]) -> dict:
 
 
 def assess_text(profile: Mapping[str, object], text: str, *, threshold: float = 0.72) -> dict:
+    """Evaluate how well a text sample matches the given voice profile.
+    
+    This function performs drift detection by comparing the text's word-frequency
+    embedding against the profile's baseline embedding using cosine similarity.
+    When the similarity falls below the threshold, the text is flagged as drifting
+    from the expected voice.
+    
+    Args:
+        profile: A voice profile dict containing 'embedding', 'include_phrases',
+            and 'avoid_phrases' keys (typically from profile_from_samples).
+        text: The text sample to evaluate against the profile.
+        threshold: Minimum cosine similarity (0.0 to 1.0) required to avoid drift.
+            Default 0.72 is calibrated for typical brand voice detection.
+            Lower values are more permissive; higher values are stricter.
+    
+    Returns:
+        A dict with keys:
+            - 'score': Cosine similarity score between 0.0 and 1.0.
+            - 'drift': Boolean indicating if score < threshold (voice drift detected).
+            - 'message': A hint for how to realign with the voice (or None if no drift).
+            - 'suggestions': List of phrase recommendations based on profile data.
+    """
     embedding = profile.get('embedding') if isinstance(profile, Mapping) else None
     score = cosine_similarity(embedding or {}, build_embedding(text))
     include_phrases = list(profile.get('include_phrases') or []) if isinstance(profile, Mapping) else []
@@ -104,6 +126,21 @@ def assess_text(profile: Mapping[str, object], text: str, *, threshold: float = 
 
 
 def evaluate_prompts(profile: Mapping[str, object], prompts: list[str], *, threshold: float = 0.72) -> list[dict]:
+    """Batch evaluate multiple text samples against a voice profile.
+    
+    This is a convenience wrapper around assess_text that processes a list of
+    prompts and returns individual assessment results for each.
+    
+    Args:
+        profile: A voice profile dict (typically from profile_from_samples).
+        prompts: List of text samples to evaluate.
+        threshold: Minimum cosine similarity (0.0 to 1.0) to avoid drift.
+            Default 0.72. See assess_text for details.
+    
+    Returns:
+        A list of assessment dicts (one per prompt), each in the format returned
+        by assess_text.
+    """
     results = []
     for text in prompts:
         results.append(assess_text(profile, text, threshold=threshold))

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -133,7 +133,7 @@ def evaluate_prompts(profile: Mapping[str, object], prompts: list[str], *, thres
             'score': round(score, 4),
             'drift': drift,
             'message': message,
-            'suggestions': suggestions
+            'suggestions': suggestions.copy()
         })
     
     return results

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -67,7 +67,7 @@ def profile_from_samples(samples: list[str]) -> dict:
     for text in cleaned:
         tokens.extend(_tokenize(text))
     include_phrases = _top_phrases(tokens, 7)
-    avoid_phrases = [t for t in include_phrases if len(t) <= 3][:3]
+    avoid_phrases = []
     avg_length = sum(len(text.split()) for text in cleaned) / len(cleaned)
     example_lines = cleaned[:3]
     return {

--- a/voice_profile.py
+++ b/voice_profile.py
@@ -1,7 +1,7 @@
 import math
 import re
 from collections import Counter
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterable, Mapping
 
 
@@ -71,7 +71,7 @@ def profile_from_samples(samples: list[str]) -> dict:
     avg_length = sum(len(text.split()) for text in cleaned) / len(cleaned)
     example_lines = cleaned[:3]
     return {
-        'created_at': datetime.utcnow().isoformat() + 'Z',
+        'created_at': datetime.now(timezone.utc).isoformat() + 'Z',
         'sample_count': len(cleaned),
         'avg_length': round(avg_length, 2),
         'include_phrases': include_phrases,


### PR DESCRIPTION
## Summary
- add voice profile ingestion endpoints that build embeddings, persist workspace samples, and feed generation prompts
- surface voice coaching in onboarding and dashboard with retraining controls, inline drift warnings, and similarity scores
- include evaluation harness covering cosine similarity guardrails

## Testing
- pytest tests/test_voice_profile.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112f3ee6c83288ced8ef503d1a8ad)