### PR TITLE
Improve reel platform spec display

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -235,6 +235,7 @@ def make_reel_plan(industry: str, pillar_name: str, brand_keywords: list[str], t
     goals = goals or []
     niche_keywords = niche_keywords or []
     length_seconds = int(length_seconds or 30)
+    overlay_safe_chars = 42  # keep overlays within vertical safe zones
 
     # industry-specific modifiers to make outputs more relevant to the professional
     industry_key = (industry or "").lower()
@@ -408,6 +409,20 @@ def make_reel_plan(industry: str, pillar_name: str, brand_keywords: list[str], t
     elif industry_key == 'artisan':
         industry_shots = ["Hands-on process close-ups, product reveal"]
 
+    variant = 'resource_light' if str(production_tier).lower() in {'solo', 'phone', 'resource-light'} else 'upgraded'
+    broll_suggestions = {
+        'resource_light': [
+            "Phone-only: handheld A-roll with window light",
+            "Quick pans of space/product; avoid gimbal for speed",
+            "Screen recordings or printed photos for cutaways"
+        ],
+        'upgraded': [
+            "Stabilized gimbal walk-through with slider cutaways",
+            "Library clips for ambience and establishing shots",
+            "Macro/detail inserts with shallow depth of field"
+        ]
+    }
+
     # convert simple descriptions into structured shots aligned to beats
     shot_list = []
     combined_shots = industry_shots + style_shots
@@ -421,11 +436,16 @@ def make_reel_plan(industry: str, pillar_name: str, brand_keywords: list[str], t
             "notes": "Match cuts to spoken lines; stable framing; consider jump cuts for energy."
         })
 
-    hashtags_all = default_hashtags(industry, brand_keywords + niche_keywords)
-    hashtags = {"primary": hashtags_all[:3], "optional": hashtags_all[3:8]}
-    thumb_prompt = f"Portrait thumbnail: {industry} • {style}. {mods.get('thumb_extra')}"
+    caption_overlays = []
+    for b in beats:
+        text = (b.get("line") or "").strip()
+        trimmed = text if len(text) <= overlay_safe_chars else text[:overlay_safe_chars - 1].rstrip() + "…"
+        caption_overlays.append({
+            "beat": b.get("osd"),
+            "text": trimmed,
+            "safe_chars": overlay_safe_chars
+        })
 
-    # generate SRT text from beats
     def fmt_ts(s):
         ms = int(s * 1000)
         h = ms // 3600000
@@ -436,6 +456,96 @@ def make_reel_plan(industry: str, pillar_name: str, brand_keywords: list[str], t
         ms = ms % 1000
         return f"{h:02d}:{m:02d}:{sec:02d},{ms:03d}"
 
+    hashtags_all = default_hashtags(industry, brand_keywords + niche_keywords)
+    hashtags = {"primary": hashtags_all[:3], "optional": hashtags_all[3:8]}
+    thumb_prompt = f"Portrait thumbnail: {industry} • {style}. {mods.get('thumb_extra')}"
+
+    first_frame_map = {
+        "Face-camera tips": "Begin mid-sentence with the hook on-screen; add a quick gesture to stop the scroll.",
+        "Property b-roll + captions": "Lead with the strongest room/feature; hold 1s before moving to the next shot.",
+        "Product b-roll + captions": "Hero close-up with brand color card behind the product for contrast.",
+        "Local hotspot montage": "Fast exterior sign shot with a quick zoom toward the entrance.",
+        "Story + before/after": "Start on the 'after' for intrigue, then rewind to the 'before'.",
+        "Workout montage": "First frame shows the hardest move with timer overlay.",
+    }
+    first_frame_idea = first_frame_map.get(style, "Lead with movement and an on-screen question to earn the first 3 seconds.")
+
+    platform_specs = [
+        {"platform": "instagram", "aspect_ratio": "9:16", "title_safe_chars": 38, "note": "Keep overlays away from bottom UI."},
+        {"platform": "tiktok", "aspect_ratio": "9:16", "title_safe_chars": 38, "note": "Safe zones top/bottom; trim overlays."},
+        {"platform": "youtube_short", "aspect_ratio": "9:16", "title_safe_chars": 45, "note": "Leave space for scrub bar."},
+    ]
+
+    thumbnail_title_ideas = [
+        {"platform": spec["platform"], "title": truncate_hook(hook, spec.get("title_safe_chars", 38)), "aspect_ratio": spec["aspect_ratio"]}
+        for spec in platform_specs
+    ]
+
+    engagement_prompts = [
+        {
+            "type": "comment",
+            "prompt": f"Comment '{industry[:3].upper() or 'YES'}' if you want the checklist/links."
+        },
+        {
+            "type": "poll",
+            "prompt": "Poll: Which part was most helpful? Hook / Tip / Example"
+        },
+        {
+            "type": "sticker",
+            "prompt": "Add a Q&A sticker: 'What should we cover next?'"
+        }
+    ]
+
+    shoot_list = []
+    for idx, (b, shot) in enumerate(zip(beats, shot_list)):
+        overlay = caption_overlays[idx] if idx < len(caption_overlays) else {"text": "", "safe_chars": overlay_safe_chars}
+        shoot_list.append({
+            "beat": b.get("osd"),
+            "start_s": b.get("start_s"),
+            "end_s": b.get("end_s"),
+            "duration_s": shot.get("duration_s"),
+            "shot": shot.get("shot_type"),
+            "overlay": overlay.get("text"),
+            "aspect_ratio": "9:16",
+            "variant": variant,
+            "timing_cue": f"{fmt_ts(b.get('start_s', 0))} → {fmt_ts(b.get('end_s', 0))}"
+        })
+
+    csv_lines = ["Beat,Overlay,Shot,Timing,Aspect Ratio,Variant"]
+    for item in shoot_list:
+        csv_lines.append(
+            ",".join([
+                (item.get("beat") or "" ).replace(",", ";"),
+                (item.get("overlay") or "" ).replace(",", ";"),
+                (item.get("shot") or "" ).replace(",", ";"),
+                (item.get("timing_cue") or "" ),
+                item.get("aspect_ratio") or "",
+                item.get("variant") or ""
+            ])
+        )
+    shoot_list_exports = {
+        "csv": "\n".join(csv_lines),
+        "pdf_text": "\n".join([
+            f"Shoot list for {style} ({variant.replace('_', ' ')})",
+            "",
+            "Aspect ratio: 9:16 (IG/TikTok/Shorts)",
+            "Timing cues include start/end stamps for each beat.",
+            "",
+            *[f"{idx+1}. {item['beat']}: {item['shot']} [{item['timing_cue']}] • Overlay: {item['overlay']}" for idx, item in enumerate(shoot_list)]
+        ])
+    }
+
+    posting_checklist = [
+        "Pin the strongest overlay as first frame text.",
+        "Trim dead air between beats; keep cuts aligned to the cues above.",
+        "Add auto-captions and double-check spelling of brand/locations.",
+        "Test placement in IG/TikTok editors to avoid UI crop in the safe zones.",
+        "Publish with the primary hashtags; reuse optional tags for comments."
+    ]
+
+    looping_hint = "End on the first frame or a question so the loop feels seamless."
+
+    # generate SRT text from beats
     srt_lines = []
     for i, b in enumerate(beats, start=1):
         start = fmt_ts(b["start_s"])
@@ -464,14 +574,35 @@ def make_reel_plan(industry: str, pillar_name: str, brand_keywords: list[str], t
         "script_beats": [b.get('line') for b in beats],
         "shot_list": shot_list,
         "on_screen_text": [b.get('osd') for b in beats],
+        "caption_overlays": caption_overlays,
+        "shoot_list": shoot_list,
+        "shoot_list_exports": shoot_list_exports,
+        "broll_suggestions": broll_suggestions.get(variant, []),
+        "first_frame_idea": first_frame_idea,
+        "engagement_prompts": engagement_prompts,
+        "posting_checklist": posting_checklist,
+        "looping_hint": looping_hint,
         "hashtags": hashtags,
         "cta": cta_line,
         "cta_variants": cta_variants,
         "thumbnail_prompt": thumb_prompt,
+        "thumbnail_title_ideas": thumbnail_title_ideas,
+        "platform_specs": platform_specs,
         "srt": srt_text,
         "music_suggestion": music,
-        "production_tier": production_tier
+        "production_tier": production_tier,
+        "variant": variant
     }
+
+
+def truncate_hook(text: str, limit: int) -> str:
+    """Shorten hook/title ideas for safe thumbnail crops."""
+    if not text:
+        return "Quick tip"
+    text = text.strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
 
 def unsplash_link(industry: str, pillar_name: str):
     q = f"{industry} {pillar_name}".replace(" ", "+")

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1329,6 +1329,10 @@ function renderPostCard(post) {
     bindCopyButton(btn, targetEditor, stampEl, card);
   });
 
+  card.querySelectorAll('[data-download-ref]').forEach(btn => {
+    bindDownloadButton(btn, card);
+  });
+
   card.querySelectorAll('[data-like]').forEach(btn => {
     btn.addEventListener('click', async () => {
       if (btn.disabled) return;
@@ -1380,10 +1384,36 @@ function renderReelSection(reel) {
   const scriptText = scriptTextParts.join('\n');
   const srtText = reel.srt_prompt || reel.srt || '';
   const thumbText = reel.thumbnail_prompt || reel.thumbnail || '';
+  const overlays = Array.isArray(reel.caption_overlays) ? reel.caption_overlays : [];
+  const broll = Array.isArray(reel.broll_suggestions) ? reel.broll_suggestions : [];
+  const shootList = Array.isArray(reel.shoot_list) ? reel.shoot_list : [];
+  const firstFrame = reel.first_frame_idea || '';
+  const engagementPrompts = Array.isArray(reel.engagement_prompts) ? reel.engagement_prompts : [];
+  const postingChecklist = Array.isArray(reel.posting_checklist) ? reel.posting_checklist : [];
+  const loopHint = reel.looping_hint || '';
+  const platformSpecs = Array.isArray(reel.platform_specs) ? reel.platform_specs : [];
+  const formatSpecChip = (spec = {}) => {
+    const name = formatPlatformLabel(spec.platform || '') || (spec.platform || '').replace('_', ' ');
+    const ratio = spec.aspect_ratio || '';
+    const safeChars = spec.title_safe_chars || spec.safe_title_chars;
+    const note = spec.note || '';
+    const safeLabel = safeChars ? ` • title ≤ ${safeChars} chars` : '';
+    return `<div class="px-2 py-1 bg-slate-100 rounded-full text-[11px] text-slate-700 border border-slate-200">${escapeHtml(name)}${ratio ? `: ${escapeHtml(ratio)}` : ''}${safeLabel}${note ? ` • ${escapeHtml(note)}` : ''}</div>`;
+  };
+  const thumbnailIdeas = Array.isArray(reel.thumbnail_title_ideas) ? reel.thumbnail_title_ideas : [];
+  const exportsCsv = reel.shoot_list_exports && reel.shoot_list_exports.csv;
+  const exportsPdf = reel.shoot_list_exports && reel.shoot_list_exports.pdf_text;
 
   const stampScript = `reel-stamp-script-${Math.random().toString(36).slice(2,8)}`;
   const stampSrt = `reel-stamp-srt-${Math.random().toString(36).slice(2,8)}`;
   const stampThumb = `reel-stamp-thumb-${Math.random().toString(36).slice(2,8)}`;
+  const exportCsvId = `shoot-csv-${Math.random().toString(36).slice(2,8)}`;
+  const exportPdfId = `shoot-pdf-${Math.random().toString(36).slice(2,8)}`;
+
+  const reelMeta = [
+    reel.length_seconds ? `${reel.length_seconds}s` : null,
+    reel.style || ''
+  ].filter(Boolean).join(' • ');
 
   return `
     <div class="mt-3 p-3 bg-slate-50 rounded border-l-4 border-purple-400">
@@ -1392,10 +1422,12 @@ function renderReelSection(reel) {
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
         </svg>
         <span class="text-sm font-medium text-purple-900">Reel Plan</span>
-        <span class="text-xs text-purple-600">(${reel.length_seconds}s • ${reel.style})</span>
+        ${reelMeta ? `<span class="text-xs text-purple-600">(${escapeHtml(reelMeta)})</span>` : ''}
       </div>
 
       <div class="text-sm mb-2"><strong>Hook:</strong> ${escapeHtml(hook)}</div>
+
+      ${firstFrame ? `<div class="text-xs text-slate-700 mb-2"><span class="font-semibold text-slate-800">First frame:</span> ${escapeHtml(firstFrame)}</div>` : ''}
 
       <div class="text-sm mb-2"><strong>Script:</strong>
         <ol class="list-decimal ml-5 text-xs text-slate-700">
@@ -1417,6 +1449,100 @@ function renderReelSection(reel) {
           <span id="${stampThumb}" class="copy-timestamp"></span>
         </div>
       </div>
+
+      ${overlays.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">Caption overlays (safe for crops)</div>
+          <ul class="list-disc ml-4 space-y-1">
+            ${overlays.map(item => `<li><span class="text-slate-500">${escapeHtml(item.beat || 'Beat')}:</span> ${escapeHtml(item.text || '')} <span class="text-slate-400">(${item.safe_chars || 0} chars)</span></li>`).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${engagementPrompts.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">Engagement prompts</div>
+          <ul class="list-disc ml-4 space-y-1">
+            ${engagementPrompts.map(item => `<li><span class="text-slate-500">${escapeHtml(item.type || '')}:</span> ${escapeHtml(item.prompt || '')}</li>`).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${shootList.length ? `
+        <div class="mt-4 text-xs text-slate-700 border border-purple-100 rounded-lg p-3 bg-white">
+          <div class="flex items-center justify-between mb-2">
+            <div class="font-semibold text-slate-900">Shoot list (${escapeHtml(reel.variant || 'resource_light')})</div>
+            <div class="flex gap-2 flex-wrap">
+              ${exportsCsv ? `<button class="btn-ghost text-xs" data-download-ref="${exportCsvId}" data-download-filename="shoot-list.csv" data-download-type="text/csv">Download CSV</button>` : ''}
+              ${exportsPdf ? `<button class="btn-ghost text-xs" data-download-ref="${exportPdfId}" data-download-filename="shoot-list.pdf" data-download-type="application/pdf">Export PDF</button>` : ''}
+            </div>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="min-w-full text-[11px]">
+              <thead>
+                <tr class="text-slate-500 text-left">
+                  <th class="py-1 pr-2">Beat</th>
+                  <th class="py-1 pr-2">Shot</th>
+                  <th class="py-1 pr-2">Overlay</th>
+                  <th class="py-1 pr-2">Timing</th>
+                  <th class="py-1 pr-2">Aspect</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-slate-100">
+                ${shootList.map(item => `
+                  <tr>
+                    <td class="py-1 pr-2 text-slate-700">${escapeHtml(item.beat || '')}</td>
+                    <td class="py-1 pr-2 text-slate-700">${escapeHtml(item.shot || '')}</td>
+                    <td class="py-1 pr-2 text-slate-700">${escapeHtml(item.overlay || '')}</td>
+                    <td class="py-1 pr-2 text-slate-500">${escapeHtml(item.timing_cue || '')}</td>
+                    <td class="py-1 pr-2 text-slate-500">${escapeHtml(item.aspect_ratio || '9:16')}</td>
+                  </tr>
+                `).join('')}
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <textarea id="${exportCsvId}" class="hidden">${escapeHtml(exportsCsv || '')}</textarea>
+        <textarea id="${exportPdfId}" class="hidden">${escapeHtml(exportsPdf || '')}</textarea>
+      ` : ''}
+
+      ${postingChecklist.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">Posting checklist</div>
+          <ul class="list-disc ml-4 space-y-1">
+            ${postingChecklist.map(item => `<li>${escapeHtml(item)}</li>`).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${loopHint ? `<div class="mt-2 text-[11px] text-slate-500">Looping tip: ${escapeHtml(loopHint)}</div>` : ''}
+
+      ${broll.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">B-roll / supporting shots</div>
+          <ul class="list-disc ml-4 space-y-1">
+            ${broll.map(line => `<li>${escapeHtml(line)}</li>`).join('')}
+          </ul>
+        </div>
+      ` : ''}
+
+      ${platformSpecs.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">Platform sizing</div>
+          <div class="flex flex-wrap gap-2">
+            ${platformSpecs.map(formatSpecChip).join('')}
+          </div>
+        </div>
+      ` : ''}
+
+      ${thumbnailIdeas.length ? `
+        <div class="mt-3 text-xs text-slate-700">
+          <div class="font-semibold text-slate-800 mb-1">Thumbnail / title ideas</div>
+          <ul class="list-disc ml-4 space-y-1">
+            ${thumbnailIdeas.map(t => `<li><span class="text-slate-500">${escapeHtml(t.platform || '')}:</span> ${escapeHtml(t.title || '')} <span class="text-slate-400">(${escapeHtml(t.aspect_ratio || '9:16')})</span></li>`).join('')}
+          </ul>
+        </div>
+      ` : ''}
     </div>
   `;
 }
@@ -1586,6 +1712,30 @@ function bindCopyButton(btn, editor, timestampEl, card){
     const original = btn.textContent;
     btn.textContent = 'Copied!';
     setTimeout(() => { btn.textContent = original || 'Copy'; }, 1500);
+  });
+}
+
+function bindDownloadButton(btn, card){
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const ref = btn.getAttribute('data-download-ref');
+    const filename = btn.getAttribute('data-download-filename') || 'shoot-list.txt';
+    const mime = btn.getAttribute('data-download-type') || 'text/plain';
+    const refNode = ref ? card.querySelector(`#${ref}`) : null;
+    const content = refNode ? (refNode.value || refNode.textContent || '') : '';
+    if (!content || !content.trim()) {
+      showToast('Nothing to download yet');
+      return;
+    }
+    const blob = new Blob([content], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
   });
 }
 

--- a/tests/test_generator_reel.py
+++ b/tests/test_generator_reel.py
@@ -50,6 +50,17 @@ def test_make_reel_plan_structure():
     assert isinstance(srt, str)
     assert beats[0]['line'] in srt
 
+    overlays = plan.get('caption_overlays') or []
+    assert overlays and all(len(item['text']) <= item['safe_chars'] for item in overlays)
+
+    shoot_list = plan.get('shoot_list') or []
+    assert shoot_list and all(item.get('aspect_ratio') == '9:16' for item in shoot_list)
+
+    assert plan.get('first_frame_idea')
+    assert plan.get('engagement_prompts')
+    assert plan.get('posting_checklist')
+    assert plan.get('looping_hint')
+
 
 if __name__ == '__main__':
     # allow running directly

--- a/tests/test_generator_unit.py
+++ b/tests/test_generator_unit.py
@@ -16,3 +16,29 @@ def test_make_reel_plan_structure():
     assert 'beats' in plan and isinstance(plan['beats'], list) and len(plan['beats']) >= 1
     assert 'srt' in plan and isinstance(plan['srt'], str) and len(plan['srt']) > 0
     assert 'thumbnail_prompt' in plan
+    assert plan.get('caption_overlays') and all(len(item['text']) <= item['safe_chars'] for item in plan['caption_overlays'])
+    assert plan.get('first_frame_idea')
+    assert plan.get('engagement_prompts')
+    assert plan.get('posting_checklist')
+    assert plan.get('looping_hint')
+
+
+def test_reel_plan_platform_and_variant_metadata():
+    light_plan = make_reel_plan(
+        'bakery', 'Pillar', ['brand'], 'friendly', company='Co', reel_style='Face-camera tips', length_seconds=20, production_tier='solo'
+    )
+    upgraded_plan = make_reel_plan(
+        'bakery', 'Pillar', ['brand'], 'friendly', company='Co', reel_style='Face-camera tips', length_seconds=20, production_tier='studio'
+    )
+
+    assert light_plan.get('variant') == 'resource_light'
+    assert upgraded_plan.get('variant') == 'upgraded'
+
+    specs = light_plan.get('platform_specs') or []
+    assert any(s.get('platform') == 'instagram' for s in specs)
+    assert any('csv' in (light_plan.get('shoot_list_exports') or {}) for _ in [0])
+
+    overlays = light_plan.get('caption_overlays') or []
+    assert overlays and all(len(item.get('text', '')) <= item.get('safe_chars', 0) for item in overlays)
+    assert light_plan.get('first_frame_idea') and light_plan.get('looping_hint')
+    assert light_plan.get('engagement_prompts') and light_plan.get('posting_checklist')


### PR DESCRIPTION
## Summary
- add first-frame guidance, engagement prompts, posting checklist, and loop hints to reel plans
- surface new reel helpers (first frame, engagement prompts, checklist, loop tip) in the dashboard reel view
- extend unit tests to cover the new reel helper fields
- refine reel platform sizing chips to include safe character guidance and handle missing metadata more gracefully

## Testing
- pytest tests/test_generator_unit.py tests/test_generator_reel.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692112f7b70083289bb230eab4cf3115)