### PR TITLE
Align CI/CD triggers with staging/main flow

### DIFF
--- a/.github/workflows/deploy-appengine.yml
+++ b/.github/workflows/deploy-appengine.yml
@@ -2,8 +2,7 @@ name: Deploy (App Engine)
 
 on:
   push:
-    branches: [main]
-    tags: ['v*']
+    branches: [staging, main]
   workflow_dispatch:
     inputs:
       environment:
@@ -25,7 +24,7 @@ concurrency:
 jobs:
   deploy-staging:
     name: Deploy staging
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/staging') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -76,7 +75,7 @@ jobs:
 
   deploy-production:
     name: Deploy production
-    if: (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -3,9 +3,8 @@ name: Deploy (Railway)
 on:
   push:
     branches:
+      - staging
       - main
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       environment:
@@ -24,7 +23,7 @@ concurrency:
 jobs:
   deploy-staging:
     name: Deploy staging (Railway)
-    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/staging') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     runs-on: ubuntu-latest
     environment: staging
     permissions:
@@ -58,7 +57,7 @@ jobs:
 
   deploy-production:
     name: Deploy production (Railway)
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,11 +7,19 @@ This runbook describes the deployment process for Togetherly, including pre-depl
 ## Current CI/CD (Railway)
 
 - **Platform:** Railway project with two environments: `staging` and `production`.
-- **Triggers:** Push to `main` deploys to staging; published GitHub release deploys to production after manual environment approval; `workflow_dispatch` supports on-demand redeploys for either environment.
+- **Triggers:** Push to `staging` deploys to staging; push to `main` deploys to production after manual environment approval; `workflow_dispatch` supports on-demand redeploys for either environment.
 - **Workflow:** `.github/workflows/deploy-railway.yml` installs Railway CLI, logs in via service token, and runs `railway up` against the appropriate environment/service.
 - **Required GitHub secrets:** `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID_STAGING`, `RAILWAY_SERVICE_ID_PRODUCTION`, `RAILWAY_TOKEN_STAGING`, `RAILWAY_TOKEN_PRODUCTION`, plus app secrets per environment (`SECRET_KEY`, Stripe keys/price/webhook, `OPENAI_API_KEY`, `ADMIN_EMAILS`, optional `GITHUB_FEEDBACK_*`, `TEAM_MEMBER_LIMIT`, `PASSWORD_HASH_METHOD`, `DATABASE_URL` if using Postgres).
 - **Railway environment vars:** Mirror the app secrets above inside each Railway environment; keep values identical across envs except for secrets/keys and webhook URLs. Healthcheck path uses `/health`.
 - **Rollback:** List deployments with `railway deployments list --project <project-id> --environment staging|production`; roll back with `railway deployment rollback <deployment-id> --project <project-id> --environment staging|production`. Validate with a smoke ping to `/health` after rollback.
+
+## Current CI/CD (App Engine)
+
+- **Platform:** Google App Engine with distinct staging and production projects.
+- **Triggers:** Push to `staging` deploys to staging; push to `main` deploys to production after environment approval; `workflow_dispatch` supports on-demand redeploys for either environment.
+- **Workflow:** `.github/workflows/deploy-appengine.yml` renders `deploy/appengine/app.yaml.tmpl` per environment and runs `gcloud app deploy` against the target project.
+- **Required GitHub secrets:** `GCP_SA_KEY_STAGING`, `GCP_PROJECT_STAGING`, `GCP_SA_KEY_PRODUCTION`, `GCP_PROJECT_PRODUCTION`, plus the app secrets referenced in the workflow for each environment (`SECRET_KEY`, Stripe keys, `OPENAI_API_KEY`, `ADMIN_EMAILS`, `GITHUB_FEEDBACK_*`, etc.).
+- **Rollback:** Use App Engine version rollback via the Google Cloud console or `gcloud app versions list` / `gcloud app services set-traffic` to shift traffic back to the previous version.
 
 ## Environments
 
@@ -32,7 +40,7 @@ This runbook describes the deployment process for Togetherly, including pre-depl
 - **URL:** TBD (e.g., togetherly.app)
 - **Purpose:** Live customer-facing application
 - **Database:** PostgreSQL (production instance with backups)
-- **Deploy Method:** CI/CD with approval gates
+- **Deploy Method:** CI/CD on merge to `main` branch with approval gates
 - **Access:** Public
 
 ## Pre-Deployment Checklist


### PR DESCRIPTION
## Summary
- trigger Railway staging deploys from the `staging` branch and production deploys from `main`
- mirror the staging/main trigger strategy in the App Engine deployment workflow
- update the deployment runbook to document the new branch-to-environment mapping and required secrets

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ce5a579083289436ee285e3ef443)