### PR TITLE
docs: add production step-by-step walkthrough

### DIFF
--- a/BRANCH_PROTECTION.md
+++ b/BRANCH_PROTECTION.md
@@ -1,0 +1,26 @@
+# Branch protection quick setup
+
+Use the provided script to enable the "CI gating on `main`" step without clicking through the GitHub UI. It applies protection with required checks that match `.github/workflows/ci.yml` and prevents force-pushes or direct pushes to `main`.
+
+## Prerequisites
+- GitHub CLI installed (`https://cli.github.com/`) and authenticated: `gh auth login`
+- `jq` installed
+- Permissions to edit branch protection rules for the repository
+
+## One-time setup
+```bash
+# From the repo root
+./scripts/apply_branch_protection.sh
+```
+This applies protection to `main` with required checks:
+- `CI / secret-scan`
+- `CI / tests`
+- `CI / triage-smoke`
+- `CI / smoke`
+
+## Customizing
+- Protect a different branch: `BRANCH_PROTECTION_BRANCH=develop ./scripts/apply_branch_protection.sh`
+- Override required checks: `BRANCH_PROTECTION_CHECKS="CI / tests,CI / smoke" ./scripts/apply_branch_protection.sh`
+- Supply the repo explicitly (useful in forks/CI): `GITHUB_REPOSITORY=owner/repo ./scripts/apply_branch_protection.sh`
+
+After running, verify in the GitHub UI under **Settings → Branches** that protection is enabled and the required checks match the ones you expect.

--- a/PRODUCTION_STEP_BY_STEP.md
+++ b/PRODUCTION_STEP_BY_STEP.md
@@ -1,0 +1,70 @@
+# Step-by-step production enablement status
+
+This walkthrough aligns with the nine-step plan you requested. Each step lists what already exists in the repo, how to validate it, and how to finish wiring anything missing.
+
+## 1) Secrets and environment variables
+- **What exists:** Test-safe CI secrets list and copy/paste commands in `CI_SECRETS.md`; local `.env` guidance in `README_ENV.md`; Railway secrets/vars required by the deploy runbook in `DEPLOYMENT.md`.
+- **How to verify:**
+  - In GitHub, open **Settings → Secrets and variables → Actions** and confirm repository secrets match the list in `CI_SECRETS.md` (no values are viewable but names should exist). For environment-scoped secrets, open **Environments → staging/production** and check the same keys as listed in `DEPLOYMENT.md`.
+  - Locally, ensure you have a `.env` by copying `.env.example` or `.env.dev`, then load it with `export $(cat .env | xargs)` before running the app.
+- **If missing:**
+  - Add the CI defaults with `gh secret set ...` from `CI_SECRETS.md`.
+  - Add Railway deploy tokens and app secrets (`RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID_*`, `RAILWAY_TOKEN_*`, `SECRET_KEY`, Stripe/OpenAI keys, `ADMIN_EMAILS`, optional `GITHUB_FEEDBACK_*`, `DATABASE_URL` if Postgres) to the `staging` and `production` environments per `DEPLOYMENT.md`.
+  - Keep the same app-secret names in Railway environment variables so deploys use them automatically.
+
+## 2) CI gating on `main`
+- **What exists:** A branch-protection helper script that sets required checks matching `.github/workflows/ci.yml` and blocks force/direct pushes.
+- **How to verify:** Run `./scripts/apply_branch_protection.sh` (requires `gh` + `jq`) and then view GitHub **Settings → Branches** to confirm `main` shows required checks: `CI / secret-scan`, `CI / tests`, `CI / triage-smoke`, `CI / smoke`.
+- **If missing:** Rerun the script with overrides as needed (e.g., `BRANCH_PROTECTION_CHECKS="CI / tests,CI / smoke"`).
+
+## 3) Railway staging/production pipeline
+- **What exists:** `.github/workflows/deploy-railway.yml` deploys on push to `main` (staging), on release publish (production), or manually via `workflow_dispatch` with an environment choice. `DEPLOYMENT.md` documents the required secrets and rollback commands.
+- **How to verify:**
+  - In GitHub Actions, open the workflow and confirm the triggers (push to `main`, release publish, manual dispatch) and that the jobs target the `staging` and `production` environments.
+  - Dry-run a manual dispatch to staging after secrets are present to confirm Railway CLI login and `railway up` succeed.
+- **If missing:** Add the Railway IDs/tokens to GitHub environment secrets and mirror app secrets inside Railway. Use the rollback commands in `DEPLOYMENT.md` to test reverting a deployment after a smoke ping to `/health`.
+
+## 4) Local environment, app run, and health checks
+- **What exists:** `.env` templates and quick-start commands to run `python3 app.py`; built-in health endpoints `/healthz` (liveness) and `/readyz` (readiness with DB/Stripe/OpenAI/GitHub checks) that back the legacy `/health` route.
+- **How to verify:**
+  - Copy `.env.dev` to `.env`, install requirements, run `python3 app.py`, and curl `http://127.0.0.1:5001/healthz` and `/readyz` to ensure the server starts and the DB check passes.
+  - Use `./scripts/e2e_run.sh` or `make e2e` for the bundled smoke test runner.
+- **If missing:** Re-create `.env` from the template, ensure SQLite file permissions allow writes, and confirm ports match `PORT` in `.env`.
+
+## 5) Stripe configuration
+- **What exists:** `README_STRIPE.md` with copy/paste commands for local webhook listening, dev user seeding, and endpoint smoke checks; reminders to use Stripe **test** keys locally and **live** keys in production.
+- **How to verify:**
+  - Run `stripe listen --forward-to http://localhost:5001/api/stripe-webhook` and copy the printed `whsec_...` into `STRIPE_WEBHOOK_SECRET`.
+  - Start the app, hit `/api/stripe-publishable-key`, and confirm a JSON response containing your test publishable key.
+- **If missing:** Fill `STRIPE_SECRET_KEY`, `STRIPE_PUBLISHABLE_KEY`, `STRIPE_PRICE_ID/STRIPE_TEST_PRICE_ID`, and `STRIPE_WEBHOOK_SECRET` in the relevant `.env`/environment secrets. For production, swap to live keys and the hosted webhook signing secret.
+
+## 6) Database choice and migrations
+- **What exists:** Runbook notes that dev runs on SQLite, while staging/production should use managed Postgres on Railway. Alembic directory is present for migrations.
+- **How to verify:**
+  - Check whether `DATABASE_URL` is set in staging/production environment secrets and in Railway env vars.
+  - If using SQLite locally, ensure `togetherly.db` is created and writable when the app starts.
+- **If missing:**
+  - Provision Railway Postgres, set `DATABASE_URL` per environment, and add Alembic migration commands to your deploy flow (e.g., a pre-deploy step or manual run) before switching traffic.
+  - Establish a backup/restore test for the chosen database.
+
+## 7) Monitoring, alerting, and health probes
+- **What exists:** Monitoring guide with metrics to track; health endpoints already return status plus dependency checks.
+- **How to verify:**
+  - Point Railway health checks to `/health` (alias for `/readyz`) and confirm 200 responses after deploy.
+  - Configure an uptime probe (e.g., GitHub scheduled action or external monitor) hitting `/healthz`.
+- **If missing:** Add exception tracking (e.g., Sentry) and create dashboards/alerts for the key metrics listed in `MONITORING.md`.
+
+## 8) Security baseline
+- **What exists:** Security best-practice guide covering auth, session settings, rate limiting, CSRF, and logging guidance.
+- **How to verify:** Review that production config enforces HTTPS, secure cookies, and rate limiting on sensitive endpoints; ensure secret scanning (Gitleaks) remains enabled via the CI job.
+- **If missing:** Apply the recommended headers/session settings, wire Flask-Limiter or equivalent, and keep secrets in GitHub/Railway env vars only.
+
+## 9) Launch polish, runbooks, and checklists
+- **What exists:** Launch quick reference plus detailed launch checklist/runbooks covering secrets, CI gating, deployment, backups, monitoring, health checks, domain/TLS, rate limiting, payments, and runbooks/SLOs.
+- **How to verify:**
+  - Walk through the “must-haves” table in `LAUNCH_CHECKLIST_QUICK_REF.md` and create issues from the linked templates.
+  - Confirm rollout/rollback steps in `DEPLOYMENT.md` and incident/runbook docs are accessible to the team.
+- **If missing:** Prioritize the must-haves list, finalize domain/TLS, ensure Stripe pricing/webhooks are live, and publish runbooks + SLOs before launch.
+
+## Local test status (this run)
+- `pytest -q -m "not e2e and not slow"` currently fails. The top issues are a `voice_profile` variable missing in `generator.py`, dev-mode toggles returning `False`, and `/api/generate` returning 500s in multiple flows. See the test output in the latest run for exact failures.

--- a/scripts/apply_branch_protection.sh
+++ b/scripts/apply_branch_protection.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[error] GitHub CLI (gh) is required. Install it from https://cli.github.com/ and run 'gh auth login'." >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "[error] jq is required to build the API payload. Install jq and retry." >&2
+  exit 1
+fi
+
+REPO=${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)}
+if [[ -z "${REPO}" ]]; then
+  echo "[error] Unable to determine repository. Set GITHUB_REPOSITORY=owner/name or run inside a cloned repo with gh configured." >&2
+  exit 1
+fi
+
+BRANCH=${BRANCH_PROTECTION_BRANCH:-main}
+
+# Default checks mirror the jobs in .github/workflows/ci.yml. Override by setting
+# BRANCH_PROTECTION_CHECKS="CI / secret-scan,CI / tests" or a space-separated list.
+DEFAULT_CHECKS=(
+  "CI / secret-scan"
+  "CI / tests"
+  "CI / triage-smoke"
+  "CI / smoke"
+)
+
+if [[ -n "${BRANCH_PROTECTION_CHECKS:-}" ]]; then
+  IFS=',' read -r -a CHECKS <<< "${BRANCH_PROTECTION_CHECKS}"
+else
+  CHECKS=(${DEFAULT_CHECKS[@]})
+fi
+
+contexts_json=$(printf '%s\n' "${CHECKS[@]}" | jq -R . | jq -s .)
+
+payload=$(jq -n \
+  --argjson contexts "${contexts_json}" \
+  '{
+    required_status_checks: { strict: true, contexts: $contexts },
+    enforce_admins: true,
+    required_pull_request_reviews: {
+      required_approving_review_count: 1,
+      dismiss_stale_reviews: true,
+      require_code_owner_reviews: false,
+      require_last_push_approval: false,
+      bypass_pull_request_allowances: { users: [], teams: [], apps: [] }
+    },
+    restrictions: null,
+    required_linear_history: true,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    block_creations: true,
+    required_conversation_resolution: true,
+    lock_branch: false,
+    allow_fork_pushes: false,
+    allow_fork_syncing: true
+  }')
+
+echo "[info] Applying branch protection to ${REPO} on branch '${BRANCH}' with required checks: ${CHECKS[*]}"
+
+gh api --method PUT "repos/${REPO}/branches/${BRANCH}/protection" --input <(echo "${payload}")
+
+echo "[done] Branch protection updated. Validate in https://github.com/${REPO}/settings/branches"


### PR DESCRIPTION
## Summary
- add a production enablement walkthrough that maps the nine-step plan to existing repo assets
- include verification steps and remediation notes for secrets, CI gating, Railway deploys, health checks, Stripe, DB, monitoring, security, and launch runbooks

## Testing
- `pytest -q -m "not e2e and not slow" --maxfail=1` *(fails: /api/generate returns 500 and generator voice_profile handling missing)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923cc9297f0832894456fb592d899a7)