### PR TITLE
Improve generator UX, telemetry, and logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -1409,16 +1409,35 @@ def api_profile():
 @app.post('/api/generate')
 def api_generate():
     data = request.get_json(force=True) or {}
-    
+
     # Check gating
     flags = load_flags()
-    platforms = data.get('platforms', [])
+    platforms = data.get('platforms') or []
+    try:
+        platforms = list(platforms)
+    except Exception:
+        platforms = []
     days = int(data.get('days') or 7)
-    
+
     uid = session.get('user_id')
     is_paid = False
     should_mark_sample = False
-    
+
+    request_meta = {
+        "event": "generator.request",
+        "user_id": uid or 'anon',
+        "days": days,
+        "platforms": platforms,
+        "has_image": bool(data.get('image_data_url')),
+        "tone": data.get('tone') or ''
+    }
+    start_ts = time.time()
+    app.logger.info("generator.request", extra=request_meta)
+
+    def _log_and_abort(status_code: int, message: str, event: str = "generator.blocked"):
+        app.logger.info(event, extra={**request_meta, "event": event, "status": status_code, "error": message})
+        return jsonify({'ok': False, 'error': message}), status_code
+
     if uid:
         db = get_db()
         u = db.execute('SELECT is_paid, free_sample_used FROM users WHERE id = ?', (uid,)).fetchone()
@@ -1429,21 +1448,21 @@ def api_generate():
     if flags.get('gate7DayToPaid'):
         if days >= 7:
             if not uid:
-                return jsonify({'ok': False, 'error': 'Login required'}), 401
+                return _log_and_abort(401, 'Login required')
             if not is_paid:
-                return jsonify({'ok': False, 'error': 'Paid plan required for 7-day generation'}), 403
+                return _log_and_abort(403, 'Paid plan required for 7-day generation')
 
     # Free sample check
     if not is_paid and uid:
         db = get_db()
         u = db.execute('SELECT free_sample_used FROM users WHERE id = ?', (uid,)).fetchone()
         if u and u['free_sample_used']:
-             return jsonify({'ok': False, 'error': 'Free sample already used'}), 403
+            return _log_and_abort(403, 'Free sample already used')
         should_mark_sample = True
 
     # Gate Reels (short_video)
     if 'short_video' in platforms and not is_paid:
-         return jsonify({'ok': False, 'error': 'Paid plan required for Reels generation'}), 403
+        return _log_and_abort(403, 'Paid plan required for Reels generation')
 
     # Check Quota for Reels
     if 'short_video' in platforms and is_paid:
@@ -1453,23 +1472,25 @@ def api_generate():
         usage = db.execute('SELECT reels_generated FROM generation_usage WHERE user_id = ? AND period = ?', (uid, period)).fetchone()
         used = usage['reels_generated'] if usage else 0
         if used >= quota:
-             return jsonify({'ok': False, 'error': 'Monthly Reels quota exceeded'}), 403
+            return _log_and_abort(403, 'Monthly Reels quota exceeded')
 
     # Check for image payload
     image_data_url = data.get('image_data_url')
     if image_data_url:
         if len(image_data_url) > IMAGE_DATA_URL_MAX_BYTES:
-             return jsonify({'ok': False, 'error': 'Image too large'}), 400
-        
+            return _log_and_abort(400, 'Image too large')
+
         try:
             # Use the helper for image-based generation
             posts = _generate_posts_from_image(data)
             if posts is None:
-                 return jsonify({'ok': False, 'error': 'Image generation not available'}), 500
+                return _log_and_abort(500, 'Image generation not available', event="generator.failed")
+            duration_ms = int((time.time() - start_ts) * 1000)
+            app.logger.info("generator.success", extra={**request_meta, "event": "generator.success", "duration_ms": duration_ms, "count": len(posts)})
             return jsonify({'ok': True, 'posts': posts, 'count': len(posts)})
         except Exception as e:
             app.logger.error(f"Image generation failed: {e}")
-            return jsonify({'ok': False, 'error': str(e)}), 500
+            return _log_and_abort(500, str(e), event="generator.failed")
 
     # Populate defaults for strict mocks
     for k in ['start_day', 'industry', 'tone', 'platforms', 'brand_keywords', 'include_images', 'niche_keywords', 'goals', 'details', 'company']:
@@ -1496,11 +1517,12 @@ def api_generate():
             db = get_db()
             db.execute('UPDATE users SET free_sample_used = 1 WHERE id = ?', (uid,))
             db.commit()
-            
+        duration_ms = int((time.time() - start_ts) * 1000)
+        app.logger.info("generator.success", extra={**request_meta, "event": "generator.success", "duration_ms": duration_ms, "count": len(posts)})
         return jsonify({'ok': True, 'posts': posts, 'count': len(posts)})
     except Exception as e:
         app.logger.error(f"Generation failed: {e}")
-        return jsonify({'ok': False, 'error': str(e)}), 500
+        return _log_and_abort(500, str(e), event="generator.failed")
 
 
 @app.post('/api/generate-review-response')

--- a/static/app.js
+++ b/static/app.js
@@ -1533,14 +1533,23 @@ async function generate(days){
     }
   }
 
+  let body;
   try{
-    return await res.json();
+    body = await res.json();
   }catch(e){
     const msg = 'Received invalid response from server.';
     showFormError(msg);
     console.error('generate() invalid json', e);
     throw new Error(msg);
   }
+
+  if (body && body.ok === false){
+    const msg = body.error || 'Unable to generate content.';
+    showFormError(msg);
+    throw new Error(msg);
+  }
+
+  return body;
 }
 
 async function seedInitialPosts(){

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -113,6 +113,37 @@ let profileDefaults = { tone: 'friendly', industry: 'Business', keywords: [], go
 let lastGeneratorState = null;
 let generatorHydratedFromProfile = false;
 
+function logGeneratorEvent(event, meta = {}) {
+  try {
+    console.info(`[generator] ${event}`, meta);
+    if (Array.isArray(window.dataLayer)) {
+      window.dataLayer.push({ event: `generator.${event}`, meta });
+    }
+  } catch (err) {
+    // ignore client logging failures
+  }
+}
+
+function setGeneratorStatus(message, tone = 'muted') {
+  const statusEl = generatorUI.statusEl || document.getElementById('generator-status');
+  if (!statusEl) return;
+  if (!message) {
+    statusEl.classList.add('hidden');
+    statusEl.textContent = '';
+    return;
+  }
+
+  const toneClasses = {
+    muted: 'text-slate-600',
+    success: 'text-green-700',
+    error: 'text-red-700'
+  };
+  const base = 'text-sm mt-2';
+  statusEl.className = `${base} ${toneClasses[tone] || toneClasses.muted}`;
+  statusEl.textContent = message;
+  statusEl.classList.remove('hidden');
+}
+
 function getCurrentUserName() {
   const user = window.CURRENT_USER || {};
   return user.name || user.full_name || user.fullName || user.email || '';
@@ -532,6 +563,7 @@ function setupContentGeneration() {
   const resultsDiv = document.getElementById('generated-content');
   const contentResults = document.getElementById('content-results');
   const reelOptions = document.getElementById('reel-options');
+  const statusEl = document.getElementById('generator-status');
   const planLengthWrap = document.getElementById('plan-length-buttons');
   const daySelect = document.getElementById('gen-days');
 
@@ -542,7 +574,7 @@ function setupContentGeneration() {
     if (btn30) btn30.classList.add('hidden');
   }
 
-  generatorUI = { generateBtn, loadingDiv, resultsDiv, contentResults, reelOptions };
+  generatorUI = { generateBtn, loadingDiv, resultsDiv, contentResults, reelOptions, statusEl };
   initGeneratorPlatformPicker();
   refreshReelOptionsVisibility();
   syncPreferredPlatformButtons();
@@ -570,23 +602,25 @@ function setupContentGeneration() {
   });
 }
 
-async function executeContentGeneration(options = {}){
-  const { daysOverride } = options;
-  const {
-    generateBtn,
-    loadingDiv,
-    resultsDiv,
-    contentResults,
-    reelOptions
-  } = generatorUI;
-  if (!document.getElementById('gen-days')){
-    showToast('Generator unavailable. Refresh and try again.');
-    return;
-  }
-  if (!ensureDashboardAuth('Create a free account to generate content.')) return;
-  const days = typeof daysOverride === 'number'
-    ? daysOverride
-    : parseInt(document.getElementById('gen-days').value);
+  async function executeContentGeneration(options = {}){
+    const { daysOverride } = options;
+    const {
+      generateBtn,
+      loadingDiv,
+      resultsDiv,
+      contentResults,
+      reelOptions,
+      statusEl
+    } = generatorUI;
+    if (!document.getElementById('gen-days')){
+      showToast('Generator unavailable. Refresh and try again.');
+      return;
+    }
+    if (!ensureDashboardAuth('Create a free account to generate content.')) return;
+    if (generateBtn?.dataset.busy === '1') return;
+    const days = typeof daysOverride === 'number'
+      ? daysOverride
+      : parseInt(document.getElementById('gen-days').value);
   if (!Number.isNaN(days)) {
     lastPlanLength = days;
   }
@@ -609,13 +643,16 @@ async function executeContentGeneration(options = {}){
     };
   }
 
-  generateBtn?.classList.add('hidden');
-  loadingDiv?.classList.remove('hidden');
+    generateBtn?.classList.add('hidden');
+    loadingDiv?.classList.remove('hidden');
+    setGeneratorStatus('Sending request to the generator…', 'muted');
+    if (generateBtn) generateBtn.dataset.busy = '1';
+    logGeneratorEvent('click', { planLength: days, platforms, tone, goalsCount: goals.length, keywordsCount: keywords.length });
 
-  try {
-    const overrides = {
-      platforms,
-      tone,
+    try {
+      const overrides = {
+        platforms,
+        tone,
       details,
       goals,
       brand_keywords: keywords
@@ -626,24 +663,35 @@ async function executeContentGeneration(options = {}){
       if (imageContext) overrides.image_context = imageContext;
     }
 
-  const data = await generate(days, overrides);
-  if (contentResults) contentResults.innerHTML = '';
-  renderPosts(data);
-  const meta = buildPlanMetadataFromPayload(data);
-  cacheGeneratedPlan(data, meta);
-  lastGeneratorState = { platforms, tone, goals, keywords, planLength: days };
-  persistTemplateLibraryState();
-  applyPlanMetadata(meta);
-    resultsDiv?.classList.remove('hidden');
-    resultsDiv?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  } catch (error) {
-    console.error('Content generation failed:', error);
-    showToast('Failed to generate content. Please try again.');
-  } finally {
-    generateBtn?.classList.remove('hidden');
-    loadingDiv?.classList.add('hidden');
+      const data = await generate(days, overrides);
+      if (!data || data.ok === false || !Array.isArray(data.posts)) {
+        const msg = (data && data.error) ? data.error : 'Generator returned no posts.';
+        throw new Error(msg);
+      }
+      if (contentResults) contentResults.innerHTML = '';
+      renderPosts(data);
+      const meta = buildPlanMetadataFromPayload(data);
+      cacheGeneratedPlan(data, meta);
+      lastGeneratorState = { platforms, tone, goals, keywords, planLength: days };
+      persistTemplateLibraryState();
+      applyPlanMetadata(meta);
+      const totalPosts = data.count || (Array.isArray(data.posts) ? data.posts.length : 0);
+      setGeneratorStatus(`Plan ready: ${totalPosts || 'draft'} posts generated.`, 'success');
+      logGeneratorEvent('success', { planLength: days, platforms, totalPosts });
+      resultsDiv?.classList.remove('hidden');
+      resultsDiv?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } catch (error) {
+      console.error('Content generation failed:', error);
+      const message = (error && error.message) ? error.message : 'Failed to generate content. Please try again.';
+      setGeneratorStatus(message, 'error');
+      logGeneratorEvent('error', { message, planLength: days, platforms });
+      showToast(message);
+    } finally {
+      generateBtn?.classList.remove('hidden');
+      loadingDiv?.classList.add('hidden');
+      if (generateBtn) delete generateBtn.dataset.busy;
+    }
   }
-}
 
 function setupImageUpload() {
   const input = document.getElementById('image-upload');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -410,6 +410,7 @@
               Generating...
             </div>
           </div>
+          <p id="generator-status" class="hidden text-sm text-slate-600" role="status" aria-live="polite"></p>
         </div>
 
         <div class="voice-summary-card mt-10">

--- a/tests/test_generate_logging.py
+++ b/tests/test_generate_logging.py
@@ -1,0 +1,14 @@
+import logging
+
+
+def test_api_generate_emits_telemetry(client, caplog):
+    with caplog.at_level(logging.INFO):
+        res = client.post('/api/generate', json={'days': 1, 'platforms': ['instagram']})
+
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data and data.get('ok') is True
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any('generator.request' in msg for msg in messages)
+    assert any('generator.success' in msg for msg in messages)


### PR DESCRIPTION
## Summary
- surface generator errors in the dashboard UI with inline status text and prevent duplicate submissions
- add client- and server-side telemetry for generator requests including start/success/error logging
- tighten generator fetch handling and add coverage ensuring request/response logs are emitted

## Testing
- pytest tests/test_api_generate_payload.py tests/test_generate_logging.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d5f0aa1d08328afac7cb9455e9854)