### PR TITLE
Clarify OpenAI requirement for image generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1480,6 +1480,13 @@ def api_generate():
         if len(image_data_url) > IMAGE_DATA_URL_MAX_BYTES:
             return _log_and_abort(400, 'Image too large')
 
+        if not USE_OPENAI or openai_client is None:
+            return _log_and_abort(
+                503,
+                'Image-to-post generation requires OpenAI. Add OPENAI_API_KEY or disable image uploads.',
+                event="generator.failed",
+            )
+
         try:
             # Use the helper for image-based generation
             posts = _generate_posts_from_image(data)

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1822,7 +1822,7 @@ function renderPublishingQueue() {
   empty.classList.add('hidden');
 
   const sorted = [...publishingQueueState.entries].sort((a, b) => (b.lastUpdated || 0) - (a.lastUpdated || 0));
-  sorted.forEach entry => list.appendChild(renderQueueItem(entry)));
+  sorted.forEach(entry => list.appendChild(renderQueueItem(entry)));
 }
 
 function renderQueueItem(entry) {
@@ -2529,6 +2529,7 @@ function renderPostCard(post) {
 
   card.querySelectorAll('[data-download-ref]').forEach(btn => {
     bindDownloadButton(btn, card);
+  });
   card.querySelectorAll('[data-export-variants]').forEach(btn => {
     btn.addEventListener('click', async () => {
       const chunks = [];

--- a/tests/test_dashboard_js.py
+++ b/tests/test_dashboard_js.py
@@ -1,0 +1,18 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def test_dashboard_js_parses():
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node not available")
+
+    result = subprocess.run(
+        [node, "--check", str(Path("static/dashboard.js"))],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"dashboard.js has syntax errors: {result.stderr or result.stdout}"

--- a/tests/test_openai_generate.py
+++ b/tests/test_openai_generate.py
@@ -114,3 +114,19 @@ def test_generate_rejects_oversized_image_payload(client):
     huge_payload = 'data:image/png;base64,' + ('a' * (appmod.IMAGE_DATA_URL_MAX_BYTES + 10))
     rv = client.post('/api/generate', json={'days': 1, 'image_data_url': huge_payload})
     assert rv.status_code == 400
+
+
+def test_image_generation_requires_openai(monkeypatch, client):
+    """If OpenAI is not configured, image-to-post should return a clear error."""
+
+    # Ensure OpenAI path is disabled
+    monkeypatch.setattr(appmod, 'USE_OPENAI', False)
+    monkeypatch.setattr(appmod, 'openai_client', None)
+
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'profile-no-openai'
+
+    rv = client.post('/api/generate', json={'days': 1, 'image_data_url': 'data:image/png;base64,AAAA'})
+    assert rv.status_code == 503
+    body = rv.get_json()
+    assert body['error'].startswith('Image-to-post generation requires OpenAI')


### PR DESCRIPTION
## Summary
- Return a clear 503 error when image-to-post generation is requested without OpenAI configured
- Guard the image generation path before calling helpers and document the requirement in the response
- Add regression coverage to assert the explicit OpenAI-required error

## Testing
- python -m pytest tests/test_openai_generate.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d641db4308328bd109e29a6ac972a)