### PR TITLE
Standardize generate API responses and add resiliency tests

### DIFF
--- a/app.py
+++ b/app.py
@@ -1459,6 +1459,8 @@ def api_profile():
 def api_generate():
     data = request.get_json(force=True) or {}
 
+    request_id = _get_request_id()
+
     # Check gating
     flags = load_flags()
     platforms = data.get('platforms') or []
@@ -1478,14 +1480,16 @@ def api_generate():
         "days": days,
         "platforms": platforms,
         "has_image": bool(data.get('image_data_url')),
-        "tone": data.get('tone') or ''
+        "tone": data.get('tone') or '',
+        "request_id": request_id,
     }
     start_ts = time.time()
     app.logger.info("generator.request", extra=request_meta)
 
-    def _log_and_abort(status_code: int, message: str, event: str = "generator.blocked"):
+    def _log_and_abort(status_code: int, message: str, event: str = "generator.blocked", code: str = "generation_failed"):
+        payload = {'ok': False, 'error': {'code': code, 'message': message}, 'request_id': request_id}
         app.logger.info(event, extra={**request_meta, "event": event, "status": status_code, "error": message})
-        return jsonify({'ok': False, 'error': message}), status_code
+        return jsonify(payload), status_code
 
     if uid:
         db = get_db()
@@ -1538,15 +1542,15 @@ def api_generate():
 
         try:
             # Use the helper for image-based generation
-            posts = _generate_posts_from_image(data)
-            if posts is None:
-                return _log_and_abort(500, 'Image generation not available', event="generator.failed")
+            posts = _generate_posts_from_image(data) or []
+            if not isinstance(posts, list) or not posts:
+                return _log_and_abort(500, 'Image generation not available', event="generator.failed", code="image_generation_failed")
             duration_ms = int((time.time() - start_ts) * 1000)
             app.logger.info("generator.success", extra={**request_meta, "event": "generator.success", "duration_ms": duration_ms, "count": len(posts)})
-            return jsonify({'ok': True, 'posts': posts, 'count': len(posts)})
-        except Exception as e:
-            app.logger.error(f"Image generation failed: {e}")
-            return _log_and_abort(500, str(e), event="generator.failed")
+            return jsonify({'ok': True, 'posts': posts, 'count': len(posts), 'request_id': request_id})
+        except Exception:
+            app.logger.exception("Image generation failed")
+            return _log_and_abort(500, 'Image generation failed. Please try again.', event="generator.failed", code="image_generation_failed")
 
     # Populate defaults for strict mocks
     for k in ['start_day', 'industry', 'tone', 'platforms', 'brand_keywords', 'include_images', 'niche_keywords', 'goals', 'details', 'company']:
@@ -1568,17 +1572,22 @@ def api_generate():
             posts = gen_mod.generate_posts_with_openai(**data)
         else:
             posts = generate_posts(**data)
-        
+
+        posts = posts or []
+        if not isinstance(posts, list) or not posts:
+            app.logger.error("Generation returned no posts", extra={**request_meta, "event": "generator.failed"})
+            return _log_and_abort(500, 'Generation failed to produce content.', event="generator.failed", code="empty_posts")
+
         if should_mark_sample and uid:
             db = get_db()
             db.execute('UPDATE users SET free_sample_used = 1 WHERE id = ?', (uid,))
             db.commit()
         duration_ms = int((time.time() - start_ts) * 1000)
         app.logger.info("generator.success", extra={**request_meta, "event": "generator.success", "duration_ms": duration_ms, "count": len(posts)})
-        return jsonify({'ok': True, 'posts': posts, 'count': len(posts)})
-    except Exception as e:
-        app.logger.error(f"Generation failed: {e}")
-        return _log_and_abort(500, str(e), event="generator.failed")
+        return jsonify({'ok': True, 'posts': posts, 'count': len(posts), 'request_id': request_id})
+    except Exception:
+        app.logger.exception("Generation failed")
+        return _log_and_abort(500, 'Generation failed. Please try again.', event="generator.failed")
 
 
 @app.post('/api/generate-review-response')

--- a/static/app.js
+++ b/static/app.js
@@ -1544,7 +1544,7 @@ async function generate(days){
   }
 
   if (body && body.ok === false){
-    const msg = body.error || 'Unable to generate content.';
+    const msg = (body.error && body.error.message) || body.error || 'Unable to generate content.';
     showFormError(msg);
     throw new Error(msg);
   }

--- a/static/complete.js
+++ b/static/complete.js
@@ -92,13 +92,19 @@ async function requestGenerate(payload){
     let msg = 'Subscribe to continue.';
     try{
       const body = await res.json().catch(()=>null);
-      if (body && body.error) msg = body.error;
+      if (body && body.error) msg = body.error.message || body.error;
     }catch(e){}
     alert(msg);
     throw new Error(msg);
   }
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return res.json();
+  const body = await res.json();
+  if (body && body.ok === false){
+    const msg = (body.error && body.error.message) || body.error || 'Unable to generate content.';
+    alert(msg);
+    throw new Error(msg);
+  }
+  return body;
 }
 
 function renderPostsComplete(posts){

--- a/tests/test_generate_api_contract.py
+++ b/tests/test_generate_api_contract.py
@@ -1,0 +1,28 @@
+def test_generate_response_contract_success(client):
+    """Successful generations should always include request metadata and posts."""
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'contract-success'
+
+    resp = client.post('/api/generate', json={'days': 1})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body['ok'] is True
+    assert body.get('request_id')
+    assert isinstance(body.get('posts'), list)
+    assert len(body['posts']) > 0
+
+
+def test_generate_response_contract_error_includes_request_id(client):
+    """Error responses must also surface the request ID for debugging."""
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'contract-error'
+
+    resp = client.post('/api/generate', json={'days': 1, 'image_data_url': 'data:image/png;base64,'})
+    assert resp.status_code in (400, 503)
+
+    body = resp.get_json()
+    assert body['ok'] is False
+    assert body.get('request_id')
+    assert 'error' in body
+    assert 'message' in body['error']

--- a/tests/test_generate_never_silent_none.py
+++ b/tests/test_generate_never_silent_none.py
@@ -1,0 +1,17 @@
+import generator as gen_mod
+
+
+def test_generate_none_payload_surfaces_error(monkeypatch, client):
+    monkeypatch.setattr(gen_mod, 'USE_OPENAI_FOR_POSTS', False)
+    monkeypatch.setattr(gen_mod, 'generate_posts', lambda **kwargs: None)
+
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'none-payload'
+
+    resp = client.post('/api/generate', json={'days': 1})
+    assert resp.status_code == 500
+
+    body = resp.get_json()
+    assert body['ok'] is False
+    assert body['error']['message']
+    assert body.get('request_id')

--- a/tests/test_generate_openai_failure_fallback.py
+++ b/tests/test_generate_openai_failure_fallback.py
@@ -1,0 +1,24 @@
+import generator as gen_mod
+
+
+def test_generate_openai_failure_uses_fallback(monkeypatch, client):
+    gen_mod.USE_OPENAI_FOR_POSTS = True
+
+    class BoomCompletions:
+        def create(self, *args, **kwargs):
+            raise RuntimeError('boom')
+
+    gen_mod._openai_client = type('Fake', (), {'chat': type('C', (), {'completions': BoomCompletions()})()})()
+
+    fallback_posts = [{'caption': 'fallback', 'platform': 'instagram'}]
+    monkeypatch.setattr(gen_mod, 'generate_posts', lambda **kwargs: fallback_posts)
+
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'openai-fallback'
+
+    resp = client.post('/api/generate', json={'days': 1})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body['ok'] is True
+    assert body['posts'][0]['caption'] == 'fallback'

--- a/tests/test_generate_openai_path_mocked.py
+++ b/tests/test_generate_openai_path_mocked.py
@@ -1,0 +1,29 @@
+import json
+
+import generator as gen_mod
+
+
+def _fake_openai_with_content(content: str):
+    class Completions:
+        def create(self, *args, **kwargs):
+            return {'choices': [{'message': {'content': content}}]}
+
+    return type('Fake', (), {'chat': type('C', (), {'completions': Completions()})()})()
+
+
+def test_generate_openai_path_parses_payload(monkeypatch, client):
+    gen_mod.USE_OPENAI_FOR_POSTS = True
+    gen_mod._openai_client = _fake_openai_with_content(json.dumps([
+        {'caption': 'from-openai', 'pillar': 'launch', 'image_prompt': 'image'}
+    ]))
+
+    with client.session_transaction() as sess:
+        sess['profile_id'] = 'openai-mock'
+
+    resp = client.post('/api/generate', json={'days': 1})
+    assert resp.status_code == 200
+
+    body = resp.get_json()
+    assert body['ok'] is True
+    assert body['posts'][0]['caption'] == 'from-openai'
+    assert body.get('request_id')

--- a/tests/test_openai_generate.py
+++ b/tests/test_openai_generate.py
@@ -1,5 +1,6 @@
 import json
 import os
+import json
 
 import app as appmod
 import generator as gen_mod
@@ -129,4 +130,4 @@ def test_image_generation_requires_openai(monkeypatch, client):
     rv = client.post('/api/generate', json={'days': 1, 'image_data_url': 'data:image/png;base64,AAAA'})
     assert rv.status_code == 503
     body = rv.get_json()
-    assert body['error'].startswith('Image-to-post generation requires OpenAI')
+    assert body['error']['message'].startswith('Image-to-post generation requires OpenAI')


### PR DESCRIPTION
## Summary
- enforce request_id-tagged, structured responses for /api/generate with validations to avoid empty payloads
- harden frontend generation error handling to surface API failures in the UI
- add regression tests covering contract guarantees, OpenAI paths, fallbacks, and non-empty post enforcement

## Testing
- pytest tests/test_generate_api_contract.py tests/test_generate_openai_path_mocked.py tests/test_generate_openai_failure_fallback.py tests/test_generate_never_silent_none.py tests/test_openai_generate.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d6fa2a9908328aa478f74ca9aabea)