### PR TITLE
Improve profile loading resilience and API contract

### DIFF
--- a/app.py
+++ b/app.py
@@ -845,6 +845,45 @@ def _deserialize_json(raw: Any, default: Any = None) -> Any:
         return default
 
 
+def _normalize_profile_payload(row: Any = None, pid: Optional[str] = None) -> dict:
+    base = {
+        'id': pid,
+        'industry': '',
+        'industry_key': '',
+        'tone': '',
+        'platforms': [],
+        'brand_keywords': [],
+        'niche_keywords': [],
+        'goals': [],
+        'company': '',
+        'include_images': False,
+        'details': {},
+        'voice_profile': {},
+        'timezone': ''
+    }
+
+    if not row:
+        return base
+
+    data = row_to_mapping(row) or {}
+    payload = dict(base)
+    payload['id'] = data.get('id') or pid or base['id']
+    payload['industry'] = data.get('industry') or ''
+    payload['industry_key'] = data.get('industry_key') or payload['industry']
+    payload['tone'] = data.get('tone') or ''
+    payload['platforms'] = _deserialize_json(data.get('platforms'), []) or []
+    payload['brand_keywords'] = _deserialize_json(data.get('brand_keywords'), []) or []
+    payload['niche_keywords'] = _deserialize_json(data.get('niche_keywords'), []) or []
+    payload['goals'] = _deserialize_json(data.get('goals'), []) or []
+    payload['company'] = data.get('company') or ''
+    payload['include_images'] = bool(data.get('include_images'))
+    payload['details'] = _deserialize_json(data.get('details'), {}) or {}
+    payload['voice_profile'] = _deserialize_json(data.get('voice_profile'), {}) or {}
+    if isinstance(payload['details'], dict):
+        payload['timezone'] = payload['details'].get('timezone') or payload['details'].get('tz') or ''
+    return payload
+
+
 def _get_current_user_row():
     uid = session.get('user_id')
     if not uid:
@@ -1359,8 +1398,9 @@ def api_account():
 
 @app.route('/api/profile', methods=['GET', 'POST'])
 def api_profile():
-    db = get_db()
+    request_id = _get_request_id()
     if request.method == 'POST':
+        db = get_db()
         data = request.get_json(force=True) or {}
         pid = session.get('profile_id')
         if not pid:
@@ -1383,12 +1423,12 @@ def api_profile():
             
         if errors:
             msg = list(errors.values())[0]
-            return jsonify({'ok': False, 'errors': errors, 'error': msg}), 400
+            return jsonify({'ok': False, 'errors': errors, 'error': msg, 'request_id': request_id}), 400
             
         include_images = 1 if data.get('include_images') else 0
         details = json.dumps(data.get('details') or {})
         voice_profile_data = json.dumps(data.get('voice_profile') or {})
-        
+
         # Upsert
         existing = db.execute('SELECT id FROM profiles WHERE id = ?', (pid,)).fetchone()
         try:
@@ -1428,31 +1468,28 @@ def api_profile():
                     INSERT INTO profiles (id, industry, tone, platforms, brand_keywords, niche_keywords, goals, company, include_images, details)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ''', (pid, industry, tone, platforms, brand_keywords, niche_keywords, goals, company, include_images, details))
-        
+
         db.commit()
-        return jsonify({'ok': True, 'id': pid})
-    
+        return jsonify({'ok': True, 'id': pid, 'request_id': request_id})
+
     else: # GET
-        pid = session.get('profile_id')
-        if not pid:
-            return jsonify({'ok': True, 'profile': None})
-        
-        row = db.execute('SELECT * FROM profiles WHERE id = ?', (pid,)).fetchone()
-        if not row:
-            return jsonify({'ok': True, 'profile': None})
-            
-        # Deserialize
-        p = dict(row)
-        p['platforms'] = _deserialize_json(p['platforms'], [])
-        p['brand_keywords'] = _deserialize_json(p['brand_keywords'], [])
-        p['niche_keywords'] = _deserialize_json(p['niche_keywords'], [])
-        p['goals'] = _deserialize_json(p['goals'], [])
-        p['details'] = _deserialize_json(p['details'], {})
-        # Use .get() to handle case where voice_profile column is missing from DB
-        p['voice_profile'] = _deserialize_json(p.get('voice_profile'), {})
-        p['include_images'] = bool(p['include_images'])
-        
-        return jsonify(p)
+        try:
+            db = get_db()
+            pid = session.get('profile_id')
+            row = None
+            if pid:
+                row = db.execute('SELECT * FROM profiles WHERE id = ?', (pid,)).fetchone()
+
+            # Deserialize
+            p = _normalize_profile_payload(row, pid)
+            return jsonify({'ok': True, 'profile': p, 'request_id': request_id})
+        except Exception as exc:
+            app.logger.exception("Failed to load profile", exc_info=exc)
+            return jsonify({
+                'ok': False,
+                'error': {'message': 'Unable to load profile right now.'},
+                'request_id': request_id
+            }), 500
 
 
 @app.post('/api/generate')

--- a/static/app.js
+++ b/static/app.js
@@ -342,7 +342,9 @@ async function loadSavedProfile(){
   try{
   const res = await fetch('/api/profile', { credentials: 'include' });
     if (!res.ok) return;
-    const p = await res.json();
+    const body = await res.json().catch(()=>null);
+    if (!body || body.ok === false) return;
+    const p = body.profile || body;
     if (!p || !p.id) return;
     // prefill inputs
     if (p.company) {

--- a/static/complete.js
+++ b/static/complete.js
@@ -51,7 +51,9 @@ function updateButtons(){
 async function fetchProfile(){
   const res = await fetch('/api/profile', { credentials: 'include' });
   if (!res.ok) return null;
-  return res.json();
+  const body = await res.json().catch(()=>null);
+  if (!body || body.ok === false) return null;
+  return body.profile || body;
 }
 
 function renderSummary(p){

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -14,6 +14,8 @@ const generatedViewPrefs = {
   hiddenPlatforms: new Set(),
   loaded: false
 };
+const PROFILE_FETCH_TIMEOUT_MS = 9000;
+const profileLoadState = { status: 'idle', error: null, requestId: null };
 const ACTIVITY_TYPE_META = {
   generated: { label: 'Generated', icon: '✨', color: 'emerald' },
   edited: { label: 'Edited', icon: '✏️', color: 'blue' },
@@ -109,7 +111,7 @@ const DEFAULT_PRESETS = [
   { id: 'product-launch', label: 'Product launch', goals: ['Product launch'], tone: 'inspirational', keywords: ['launch', 'new feature'] },
   { id: 'weekly-update', label: 'Weekly update', goals: ['Weekly update'], tone: 'friendly', keywords: ['community', 'newsletter'] }
 ];
-let profileDefaults = { tone: 'friendly', industry: 'Business', keywords: [], goals: [], id: 'anon' };
+let profileDefaults = { tone: 'friendly', industry: 'Business', keywords: [], goals: [], platforms: [], company: '', timezone: '', id: 'anon', hasProfile: false };
 let lastGeneratorState = null;
 let generatorHydratedFromProfile = false;
 
@@ -243,6 +245,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const hasFeedbackForm = Boolean(document.getElementById('feedback-form'));
   const hasActivityPanel = Boolean(document.getElementById('activity-panel'));
 
+  setupProfileLoadBannerActions();
+
   loadUserProfile({ hydrateGenerator: hasGenerator, hydrateVoice: hasVoiceCoach || document.getElementById('voice-coach-summary') });
 
   if (hasReviewPanel) {
@@ -280,35 +284,140 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 async function loadUserProfile(options = {}) {
-  const { hydrateGenerator = true, hydrateVoice = true } = options;
+  const { hydrateGenerator = true, hydrateVoice = true, force = false } = options;
+  if (profileLoadState.status === 'loading' && !force) return;
+
+  profileLoadState.status = 'loading';
+  profileLoadState.error = null;
+  renderProfileLoadBanner();
+
   try {
     await ensureAccountFormFields();
-    const response = await fetch('/api/profile', { credentials: 'include' });
-    let profile = {};
-    if (response.ok) {
-      profile = await response.json();
-      applyProfileToAccountForm(profile);
-    }
-    profileDefaults = {
-      tone: profile.tone || 'friendly',
-      industry: profile.industry || profile.industry_key || 'Business',
-      keywords: Array.isArray(profile.brand_keywords) ? profile.brand_keywords : [],
-      goals: Array.isArray(profile.goals) ? profile.goals : [],
-      id: profile.id || (window.CURRENT_USER && window.CURRENT_USER.id) || 'anon'
-    };
-    setTemplateProfileKey(profileDefaults.id);
-    renderProfileDefaultsSummary(profileDefaults);
-    hydrateTemplateLibrary();
-    renderCollaborationSummary();
-    if (hydrateGenerator) {
-      applyProfileDefaultsToGenerator(profileDefaults);
-      hydrateStoredGeneratorState({ apply: true, preferProfile: true });
-    }
-    if (hydrateVoice) {
-      hydrateVoiceSummary(profile || {});
-    }
+  } catch (err) {
+    /* ignore form prep errors */
+  }
+
+  let profile = null;
+  let response = null;
+  let body = null;
+  let fetchError = null;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(new Error('profile-timeout')), PROFILE_FETCH_TIMEOUT_MS);
+
+  try {
+    response = await fetch('/api/profile', { credentials: 'include', signal: controller.signal });
+    body = await response.json().catch(() => null);
   } catch (error) {
-    console.error('Failed to load user profile:', error);
+    fetchError = error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  if (response && response.ok && body && body.ok !== false) {
+    profile = normalizeProfileResponse(body);
+    profileLoadState.status = 'loaded';
+    profileLoadState.requestId = body.request_id || null;
+  } else {
+    const timedOut = fetchError && fetchError.name === 'AbortError';
+    const errorMessage = (body && body.error && body.error.message)
+      || (timedOut ? 'Profile request timed out. Please retry.' : (fetchError && fetchError.message))
+      || (response ? `Profile request failed (HTTP ${response.status})` : 'Profile request failed.');
+    profileLoadState.status = 'error';
+    profileLoadState.error = errorMessage;
+    profileLoadState.requestId = (body && body.request_id) || null;
+  }
+
+  if (profile && typeof profile === 'object') {
+    try { applyProfileToAccountForm(profile); } catch (err) { /* ignore */ }
+  }
+
+  profileDefaults = buildProfileDefaults(profile);
+  setTemplateProfileKey(profileDefaults.id);
+  renderProfileDefaultsSummary(profileDefaults);
+  renderProfileLoadBanner();
+  hydrateTemplateLibrary();
+  renderCollaborationSummary();
+
+  if (hydrateGenerator) {
+    applyProfileDefaultsToGenerator(profileDefaults);
+    hydrateStoredGeneratorState({ apply: true, preferProfile: true });
+  }
+
+  if (hydrateVoice) {
+    hydrateVoiceSummary(profileDefaults, { profileMissing: !profileDefaults.hasProfile });
+  }
+
+  const statusEl = document.getElementById('generator-status');
+  if (statusEl && profileLoadState.status !== 'error') {
+    statusEl.classList.add('hidden');
+    statusEl.textContent = '';
+  }
+
+  if (profileLoadState.status === 'error') {
+    if (statusEl) {
+      statusEl.textContent = `${profileLoadState.error} Using defaults for now.`;
+      statusEl.classList.remove('hidden');
+    }
+    console.error('Failed to load user profile:', profileLoadState.error);
+  }
+}
+
+function normalizeProfileResponse(payload = {}) {
+  if (!payload) return null;
+  if (typeof payload === 'object' && Object.prototype.hasOwnProperty.call(payload, 'profile')) {
+    return payload.profile;
+  }
+  return payload;
+}
+
+function buildProfileDefaults(profile = null) {
+  const source = profile && typeof profile === 'object' ? profile : {};
+  const platforms = Array.isArray(source.platforms) ? source.platforms : [];
+  const keywords = Array.isArray(source.brand_keywords) ? source.brand_keywords : [];
+  const goals = Array.isArray(source.goals) ? source.goals : [];
+  const hasProfile = Boolean(source.id || source.company || source.industry || source.industry_key || source.tone || platforms.length || keywords.length || goals.length);
+  return {
+    tone: source.tone || 'friendly',
+    industry: source.industry || source.industry_key || 'Business',
+    keywords,
+    goals,
+    platforms,
+    company: source.company || '',
+    timezone: source.timezone || '',
+    id: source.id || (window.CURRENT_USER && window.CURRENT_USER.id) || 'anon',
+    hasProfile,
+    voice_profile: source.voice_profile || {}
+  };
+}
+
+function renderProfileLoadBanner() {
+  const banner = document.getElementById('profile-load-banner');
+  if (!banner) return;
+  const title = document.getElementById('profile-banner-title');
+  const message = document.getElementById('profile-banner-message');
+  const shouldShow = profileLoadState.status === 'error';
+  banner.classList.toggle('hidden', !shouldShow);
+  if (!shouldShow) return;
+  if (title) title.textContent = 'Profile failed to load';
+  if (message) {
+    const detail = profileLoadState.error || 'Something went wrong while loading your profile.';
+    const rid = profileLoadState.requestId ? ` (request ${profileLoadState.requestId})` : '';
+    message.textContent = `${detail}${rid}`;
+  }
+}
+
+function setupProfileLoadBannerActions() {
+  const retry = document.getElementById('profile-banner-retry');
+  if (retry) {
+    retry.addEventListener('click', () => loadUserProfile({ hydrateGenerator: true, hydrateVoice: true, force: true }));
+  }
+  const cont = document.getElementById('profile-banner-continue');
+  if (cont) {
+    cont.addEventListener('click', () => {
+      profileLoadState.status = 'loaded';
+      profileLoadState.error = null;
+      renderProfileLoadBanner();
+    });
   }
 }
 
@@ -1392,7 +1501,7 @@ function renderProfileDefaultsSummary(defaults = {}) {
   details.push(`Industry: ${industry}`);
   if (keywords.length) details.push(`Keywords: ${keywords.join(', ')}`);
   if (goalSnippet.length) details.push(`Goals: ${goalSnippet.join(', ')}`);
-  target.textContent = details.join(' • ');
+  target.textContent = (defaults.hasProfile ? '' : 'Using defaults — ') + details.join(' • ');
 }
 
 function applyProfileDefaultsToGenerator(defaults = {}) {
@@ -1400,6 +1509,9 @@ function applyProfileDefaultsToGenerator(defaults = {}) {
   const toneField = document.getElementById('gen-tone');
   if (toneField && defaults.tone) {
     toneField.value = defaults.tone;
+  }
+  if (Array.isArray(defaults.platforms) && defaults.platforms.length) {
+    setGeneratorPlatformSelections(defaults.platforms);
   }
   if (defaults.industry) {
     try { answers.industry = defaults.industry; } catch (err) { /* ignore */ }
@@ -3481,7 +3593,7 @@ function getPreferredGeneratorPlatforms() {
   return [DEFAULT_GENERATOR_PLATFORM];
 }
 
-function hydrateVoiceSummary(data = {}){
+function hydrateVoiceSummary(data = {}, options = {}){
   const fallbackAnswers = (typeof answers !== 'undefined') ? answers : {};
   const source = { ...data };
   const formSnapshot = collectAccountFormProfile();
@@ -3502,10 +3614,12 @@ function hydrateVoiceSummary(data = {}){
     else if (Array.isArray(fallbackAnswers.platforms) && fallbackAnswers.platforms.length) source.platforms = fallbackAnswers.platforms;
     else source.platforms = ['instagram'];
   }
-  setVoiceSummaryField('company', source.company || 'Not set');
-  setVoiceSummaryField('industry', resolveIndustryLabel(source.industry || source.industry_key));
-  setVoiceSummaryField('tone', formatToneLabel(source.tone));
-  setVoiceSummaryField('platforms', source.platforms.map(formatPlatformLabel).join(', '));
+  const missingLabel = options.profileMissing ? 'Not set — ' : 'Not set — ';
+  const ctaLabel = options.profileMissing ? 'Set voice' : 'Update voice';
+  setVoiceSummaryField('company', source.company || '', { missingLabel, ctaLabel });
+  setVoiceSummaryField('industry', resolveIndustryLabel(source.industry || source.industry_key), { missingLabel, ctaLabel });
+  setVoiceSummaryField('tone', formatToneLabel(source.tone), { missingLabel, ctaLabel });
+  setVoiceSummaryField('platforms', source.platforms.map(formatPlatformLabel).join(', '), { missingLabel, ctaLabel });
   const pill = document.getElementById('voice-pill');
   if (pill){
     pill.textContent = source.company ? `Voice locked: ${source.company}` : 'Voice ready to sync';
@@ -3513,9 +3627,25 @@ function hydrateVoiceSummary(data = {}){
   updateToneNote(source.tone);
 }
 
-function setVoiceSummaryField(key, value){
+function setVoiceSummaryField(key, value, opts = {}){
   const el = document.querySelector(`[data-voice-${key}]`);
-  if (el) el.textContent = value && value.trim() ? value : '—';
+  if (!el) return;
+  const hasValue = value && String(value).trim();
+  if (hasValue) {
+    el.textContent = value;
+    el.classList.remove('text-amber-700');
+    return;
+  }
+  el.textContent = '';
+  el.classList.add('text-amber-700');
+  const prefix = document.createElement('span');
+  prefix.textContent = opts.missingLabel || 'Not set — ';
+  const link = document.createElement('a');
+  link.href = '/settings';
+  link.className = 'text-indigo-600 underline';
+  link.textContent = opts.ctaLabel || 'Set now';
+  el.appendChild(prefix);
+  el.appendChild(link);
 }
 
 function formatToneLabel(value){

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -164,6 +164,21 @@
           <div class="planner-pill" id="voice-pill">Syncing voice from wizard…</div>
         </div>
 
+        <div id="profile-load-banner" class="hidden mb-4 p-4 rounded-2xl border border-amber-200 bg-amber-50">
+          <div class="flex items-start gap-3">
+            <div class="w-10 h-10 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-lg">⚠️</div>
+            <div class="flex-1">
+              <p id="profile-banner-title" class="text-sm font-semibold text-amber-900">Profile failed to load</p>
+              <p id="profile-banner-message" class="text-sm text-amber-800">We couldn’t fetch your defaults. Continue with built-in settings or retry.</p>
+              <div class="mt-3 flex gap-2 flex-wrap">
+                <button id="profile-banner-retry" class="btn-primary btn-sm" type="button">Retry</button>
+                <a href="/settings" class="btn-secondary btn-sm">Open Settings</a>
+                <button id="profile-banner-continue" class="btn-ghost btn-sm" type="button">Continue with defaults</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="planner-card space-y-8">
           <div class="planner-recipes bg-gradient-to-r from-indigo-50 to-purple-50 p-5 rounded-2xl border border-indigo-100">
             <div class="mb-3">
@@ -424,15 +439,15 @@
           <dl class="voice-summary-grid">
             <div>
               <dt>Company</dt>
-              <dd data-voice-company>—</dd>
+              <dd data-voice-company>Not set</dd>
             </div>
             <div>
               <dt>Industry</dt>
-              <dd data-voice-industry>—</dd>
+              <dd data-voice-industry>Not set</dd>
             </div>
             <div>
               <dt>Signature tone</dt>
-              <dd data-voice-tone>—</dd>
+              <dd data-voice-tone>Not set</dd>
             </div>
             <div>
               <dt>Platforms</dt>

--- a/templates/generate_social.html
+++ b/templates/generate_social.html
@@ -81,6 +81,21 @@
           <div class="planner-pill" id="voice-pill">Syncing voice from wizard…</div>
         </div>
 
+        <div id="profile-load-banner" class="hidden mb-4 p-4 rounded-2xl border border-amber-200 bg-amber-50">
+          <div class="flex items-start gap-3">
+            <div class="w-10 h-10 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center text-lg">⚠️</div>
+            <div class="flex-1">
+              <p id="profile-banner-title" class="text-sm font-semibold text-amber-900">Profile failed to load</p>
+              <p id="profile-banner-message" class="text-sm text-amber-800">We couldn’t fetch your defaults. Continue with built-in settings or retry.</p>
+              <div class="mt-3 flex gap-2 flex-wrap">
+                <button id="profile-banner-retry" class="btn-primary btn-sm" type="button">Retry</button>
+                <a href="/settings" class="btn-secondary btn-sm">Open Settings</a>
+                <button id="profile-banner-continue" class="btn-ghost btn-sm" type="button">Continue with defaults</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="planner-card space-y-8">
           <div class="planner-recipes bg-gradient-to-r from-indigo-50 to-purple-50 p-5 rounded-2xl border border-indigo-100">
             <div class="mb-3">
@@ -341,15 +356,15 @@
         <dl class="voice-summary-grid">
           <div>
             <dt>Company</dt>
-            <dd data-voice-company>—</dd>
+            <dd data-voice-company>Not set</dd>
           </div>
           <div>
             <dt>Industry</dt>
-            <dd data-voice-industry>—</dd>
+            <dd data-voice-industry>Not set</dd>
           </div>
           <div>
             <dt>Signature tone</dt>
-            <dd data-voice-tone>—</dd>
+            <dd data-voice-tone>Not set</dd>
           </div>
           <div>
             <dt>Platforms</dt>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -133,15 +133,15 @@
           <dl class="voice-summary-grid">
             <div>
               <dt>Company</dt>
-              <dd data-voice-company>—</dd>
+              <dd data-voice-company>Not set</dd>
             </div>
             <div>
               <dt>Industry</dt>
-              <dd data-voice-industry>—</dd>
+              <dd data-voice-industry>Not set</dd>
             </div>
             <div>
               <dt>Signature tone</dt>
-              <dd data-voice-tone>—</dd>
+              <dd data-voice-tone>Not set</dd>
             </div>
             <div>
               <dt>Platforms</dt>

--- a/tests/test_acceptance_api.py
+++ b/tests/test_acceptance_api.py
@@ -81,7 +81,9 @@ def test_acceptance_api():
 
     r = session.get(f"{BASE}/api/profile")
     assert r.status_code == 200
-    prof = r.json()
+    prof_body = r.json()
+    assert prof_body.get('ok') is True
+    prof = prof_body.get('profile') or {}
     assert prof.get('company') == 'Testco Llc' or prof.get('company') == 'TestCo LLC'
 
     # Toggle gating flag to require paid for 7-day generation

--- a/tests/test_profile_api_contract.py
+++ b/tests/test_profile_api_contract.py
@@ -1,0 +1,46 @@
+import pytest
+from app import app
+
+
+def test_profile_api_contract(client):
+    payload = {
+        'company': 'Contract Co',
+        'tone': 'playful',
+        'platforms': ['instagram', 'linkedin']
+    }
+    create_resp = client.post('/api/profile', json=payload)
+    assert create_resp.status_code == 200
+    created_body = create_resp.get_json()
+    assert created_body.get('ok') is True
+    assert created_body.get('request_id')
+
+    resp = client.get('/api/profile')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get('ok') is True
+    assert body.get('request_id')
+    profile = body.get('profile')
+    assert isinstance(profile, dict)
+
+    for key in ('company', 'industry', 'tone', 'platforms', 'timezone'):
+        assert key in profile
+    assert profile.get('company').lower().startswith('contract')
+    assert isinstance(profile.get('platforms'), list)
+    assert isinstance(profile.get('brand_keywords'), list)
+    assert isinstance(profile.get('goals'), list)
+    assert profile.get('timezone') == ''
+    assert profile.get('industry') == ''
+    assert profile.get('tone') == 'playful'
+
+
+def test_profile_missing_fields_are_defaults(client):
+    resp = client.get('/api/profile')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body.get('ok') is True
+    profile = body.get('profile') or {}
+    assert profile.get('company') == ''
+    assert profile.get('industry') == ''
+    assert profile.get('tone') == ''
+    assert profile.get('platforms') == []
+    assert profile.get('timezone') == ''

--- a/tests/test_profile_load_failure_returns_error_json.py
+++ b/tests/test_profile_load_failure_returns_error_json.py
@@ -1,0 +1,14 @@
+import app
+
+
+def test_profile_load_failure_returns_error_json(monkeypatch, client):
+    def boom():
+        raise RuntimeError('db unavailable')
+
+    monkeypatch.setattr(app, 'get_db', boom)
+    resp = client.get('/api/profile')
+    assert resp.status_code == 500
+    data = resp.get_json()
+    assert data.get('ok') is False
+    assert data.get('request_id')
+    assert data.get('error', {}).get('message')

--- a/tests/test_profile_persistence.py
+++ b/tests/test_profile_persistence.py
@@ -23,7 +23,9 @@ def test_profile_save_and_get(client):
 
     r2 = client.get('/api/profile')
     assert r2.status_code == 200
-    prof = r2.get_json()
+    body = r2.get_json()
+    assert body.get('ok') is True
+    prof = body.get('profile') or {}
     # Company capitalization can be normalized by the app (title() may change punctuation);
     # compare in a case-insensitive, punctuation-agnostic way.
     company_saved = prof.get('company', '') or ''


### PR DESCRIPTION
## Summary
- add server-side profile normalization with request IDs, consistent defaults, and structured error responses
- build a deterministic frontend profile load flow with timeout, visible error banner actions, and safer voice snapshot fallbacks
- expand profile contract coverage with new tests and adjust existing callers to the updated API shape

## Testing
- pytest tests/test_profile_api_contract.py tests/test_profile_load_failure_returns_error_json.py tests/test_profile_persistence.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d723991988328a6027aabfe1e8e0a)