### PR TITLE
Add debug APIs and enforce request IDs

### DIFF
--- a/app.py
+++ b/app.py
@@ -227,6 +227,39 @@ def _get_request_id() -> str:
     return rid
 
 
+def _ensure_request_id_in_response(response):
+    """Attach request_id to JSON responses when missing.
+
+    This keeps the API contract consistent without altering legacy
+    endpoints that intentionally omit additional keys (e.g. profile).
+    """
+
+    # Avoid mutating profile contract (handled separately in BUG-001)
+    if request.path.startswith('/api/profile'):
+        return response
+
+    if not response.is_json:
+        return response
+
+    try:
+        data = response.get_json(silent=True)
+    except Exception:
+        return response
+
+    if not isinstance(data, dict):
+        return response
+
+    if 'request_id' in data:
+        return response
+
+    data['request_id'] = _get_request_id()
+
+    # Preserve status code/headers while updating JSON body
+    response.set_data(json.dumps(data))
+    response.headers['Content-Type'] = 'application/json'
+    return response
+
+
 class RequestIdFilter(logging.Filter):
     def filter(self, record):
         record.request_id = getattr(g, 'request_id', 'n/a')
@@ -566,6 +599,7 @@ def _attach_request_id():
 @app.after_request
 def _set_request_id_header(response):
     try:
+        response = _ensure_request_id_in_response(response)
         response.headers['X-Request-Id'] = _get_request_id()
     except Exception:
         pass
@@ -934,6 +968,66 @@ def readyz():
 def legacy_health():
     """Back-compat endpoint; proxies to /readyz."""
     return readyz()
+
+
+@app.get('/api/debug/health')
+def api_debug_health():
+    request_id = _get_request_id()
+    healthy, db_error = _db_healthcheck()
+    db_info = {
+        'type': 'postgres' if USE_POSTGRES else 'sqlite',
+        'status': 'connected' if healthy else 'unhealthy',
+        'error': db_error if not healthy else None,
+    }
+
+    checks = {
+        'database': 'connected' if healthy else f"unhealthy: {db_error or 'unknown'}",
+        'stripe': 'configured' if (os.getenv('STRIPE_SECRET_KEY') and stripe) else 'not_configured',
+        'openai': 'configured' if USE_OPENAI else 'not_configured',
+        'github_feedback': 'configured' if GITHUB_FEEDBACK_TOKEN else 'not_configured',
+    }
+
+    status = 'healthy' if healthy else 'unhealthy'
+    status_code = 200 if healthy else 503
+    payload = {
+        'ok': healthy,
+        'request_id': request_id,
+        'status': status,
+        'version': os.getenv('APP_VERSION', 'dev'),
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'checks': checks,
+        'db': db_info,
+    }
+    return jsonify(payload), status_code
+
+
+@app.get('/api/debug/openai-status')
+def api_debug_openai_status():
+    request_id = _get_request_id()
+    configured = bool(os.getenv('OPENAI_API_KEY'))
+    client_ready = bool(USE_OPENAI and openai_client is not None)
+
+    reason = None
+    if OUTBOUND_KILL_SWITCH:
+        reason = 'outbound_kill_switch'
+    elif not configured:
+        reason = 'missing_api_key'
+    elif not client_ready:
+        reason = 'client_not_initialized'
+
+    payload = {
+        'ok': True,
+        'request_id': request_id,
+        'status': 'enabled' if client_ready and not OUTBOUND_KILL_SWITCH else 'disabled',
+        'configured': configured,
+        'kill_switch_active': bool(OUTBOUND_KILL_SWITCH),
+        'client_ready': client_ready,
+    }
+
+    if reason:
+        payload['reason'] = reason
+
+    return jsonify(payload)
 
 def _initial_user_payload():
     uid = session.get('user_id')

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,0 +1,18 @@
+
+def test_debug_health_endpoint_contract(client):
+    response = client.get('/api/debug/health')
+    assert response.status_code in (200, 503)
+
+    body = response.get_json()
+    assert 'ok' in body
+    assert body.get('request_id')
+    assert body.get('status') in {'healthy', 'unhealthy'}
+    assert 'checks' in body
+    assert 'db' in body
+    assert 'version' in body
+    assert 'timestamp' in body
+    assert 'openai' in body['checks']
+    assert 'database' in body['checks']
+
+    if body['ok']:
+        assert response.status_code == 200

--- a/tests/test_openai_status_endpoint.py
+++ b/tests/test_openai_status_endpoint.py
@@ -1,0 +1,12 @@
+
+def test_openai_status_endpoint_returns_contract(client):
+    response = client.get('/api/debug/openai-status')
+    assert response.status_code == 200
+
+    body = response.get_json()
+    assert body['ok'] is True
+    assert body.get('request_id')
+    assert body.get('status') in {'enabled', 'disabled'}
+    assert isinstance(body.get('configured'), bool)
+    assert isinstance(body.get('kill_switch_active'), bool)
+    assert isinstance(body.get('client_ready'), bool)

--- a/tests/test_request_id_present.py
+++ b/tests/test_request_id_present.py
@@ -1,0 +1,24 @@
+import re
+
+
+def test_request_id_in_header_and_body(client):
+    response = client.get('/health')
+    assert response.status_code in (200, 503)
+
+    # Header should always include a request id
+    rid_header = response.headers.get('X-Request-Id')
+    assert rid_header
+    assert re.fullmatch(r"[0-9a-f]{8}", rid_header)
+
+    data = response.get_json()
+    assert data
+    assert data.get('request_id') == rid_header
+
+
+def test_request_id_added_to_non_api_json(client):
+    response = client.get('/healthz')
+    assert response.status_code == 200
+
+    data = response.get_json()
+    assert data
+    assert 'request_id' in data


### PR DESCRIPTION
## Summary
- ensure JSON responses automatically include a request_id while leaving the profile API contract unchanged
- add debug health and OpenAI status endpoints that return ok/request_id plus service details
- add tests covering request_id propagation and the new debug endpoints

## Testing
- pytest tests/test_request_id_present.py tests/test_openai_status_endpoint.py tests/test_health_endpoint.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d73d124048328841b2b8e3e2abd46)