### PR TITLE
Add template library API with preview and undo workflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -768,6 +768,17 @@ def init_db():
             message TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         );
+        CREATE TABLE IF NOT EXISTS templates (
+            id TEXT PRIMARY KEY,
+            owner_user_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            scope TEXT DEFAULT 'personal',
+            payload TEXT,
+            preview TEXT,
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE INDEX IF NOT EXISTS idx_templates_owner_scope ON templates(owner_user_id, scope);
         """
     )
     # Backfill for upgrades
@@ -877,6 +888,16 @@ def _deserialize_json(raw: Any, default: Any = None) -> Any:
         return json.loads(raw)
     except Exception:
         return default
+
+
+def _serialize_template_row(row):
+    if not row:
+        return None
+    data = row_to_mapping(row) or {}
+    data['payload'] = _deserialize_json(data.get('payload'), {})
+    if data.get('updated_at') and not data.get('updatedAt'):
+        data['updatedAt'] = data['updated_at']
+    return data
 
 
 def _normalize_profile_payload(row: Any = None, pid: Optional[str] = None) -> dict:
@@ -2754,8 +2775,218 @@ def api_feedback():
     except Exception:
         logging.exception("Feedback save failed")
         pass
-        
+
     return jsonify({'ok': True})
+
+
+def _current_user_id() -> Optional[str]:
+    return session.get('user_id')
+
+
+def _template_owner_where_clause():
+    return 'owner_user_id = ?'
+
+
+@app.route('/api/templates', methods=['GET', 'POST'])
+def api_templates():
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({'ok': False, 'error': 'Unauthorized'}), 401
+
+    db = get_db()
+
+    if request.method == 'GET':
+        scope = (request.args.get('scope') or 'all').lower()
+        params = [user_id]
+        where = _template_owner_where_clause()
+        if scope in {'personal', 'workspace'}:
+            where = where + ' AND LOWER(scope) = ?'
+            params.append(scope)
+        rows = db.execute(
+            f'SELECT * FROM templates WHERE {where} ORDER BY updated_at DESC',
+            tuple(params)
+        ).fetchall()
+        templates = [_serialize_template_row(r) for r in rows]
+        return jsonify({'ok': True, 'templates': templates})
+
+    data = request.get_json(silent=True) or {}
+    name = (data.get('name') or '').strip()
+    if not name:
+        return jsonify({'ok': False, 'error': 'Name is required'}), 400
+    scope = (data.get('scope') or 'personal').strip().lower()
+    if scope not in {'personal', 'workspace'}:
+        scope = 'personal'
+    payload = data.get('payload') or data.get('template') or {}
+    preview = data.get('preview') or ''
+    now_iso = datetime.now(timezone.utc).isoformat()
+    template_id = data.get('id') or str(uuid.uuid4())
+
+    try:
+        db.execute(
+            '''INSERT INTO templates (id, owner_user_id, name, scope, payload, preview, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+            (
+                template_id,
+                user_id,
+                name,
+                scope,
+                json.dumps(payload),
+                preview,
+                now_iso,
+                now_iso,
+            )
+        )
+        db.commit()
+    except DB_INTEGRITY_ERRORS:
+        return jsonify({'ok': False, 'error': 'Duplicate template id'}), 409
+    except Exception as exc:
+        logging.exception("Template save failed")
+        return jsonify({'ok': False, 'error': str(exc)}), 500
+
+    template = _serialize_template_row(
+        db.execute('SELECT * FROM templates WHERE id = ?', (template_id,)).fetchone()
+    )
+    status_code = 201
+    return jsonify({'ok': True, 'template': template}), status_code
+
+
+@app.route('/api/templates/<template_id>', methods=['GET', 'DELETE'])
+def api_template_detail(template_id):
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({'ok': False, 'error': 'Unauthorized'}), 401
+
+    db = get_db()
+    row = db.execute(
+        f'SELECT * FROM templates WHERE id = ? AND {_template_owner_where_clause()}',
+        (template_id, user_id),
+    ).fetchone()
+    if not row:
+        return jsonify({'ok': False, 'error': 'Not found'}), 404
+
+    if request.method == 'GET':
+        return jsonify({'ok': True, 'template': _serialize_template_row(row)})
+
+    # DELETE
+    db.execute('DELETE FROM templates WHERE id = ?', (template_id,))
+    db.commit()
+    return jsonify({'ok': True})
+
+
+@app.post('/api/templates/<template_id>/apply')
+def api_template_apply(template_id):
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({'ok': False, 'error': 'Unauthorized'}), 401
+
+    data = request.get_json(silent=True) or {}
+    draft_id = data.get('draft_id')
+    if not draft_id:
+        return jsonify({'ok': False, 'error': 'draft_id is required'}), 400
+
+    db = get_db()
+    template_row = db.execute(
+        f'SELECT * FROM templates WHERE id = ? AND {_template_owner_where_clause()}',
+        (template_id, user_id)
+    ).fetchone()
+    if not template_row:
+        return jsonify({'ok': False, 'error': 'Not found'}), 404
+
+    draft_row = db.execute(
+        'SELECT * FROM team_drafts WHERE id = ? AND owner_user_id = ?',
+        (draft_id, user_id)
+    ).fetchone()
+    if not draft_row:
+        return jsonify({'ok': False, 'error': 'Draft not found'}), 404
+
+    template_payload = _serialize_template_row(template_row).get('payload') or {}
+    draft_payload = template_payload.get('draft') or template_payload.get('content') or template_payload
+    if draft_payload is None:
+        draft_payload = {}
+
+    previous_snapshot = draft_row['content']
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    db.execute(
+        'UPDATE team_drafts SET content = ?, updated_at = ? WHERE id = ?',
+        (json.dumps(draft_payload), now_iso, draft_id)
+    )
+    db.execute(
+        '''INSERT INTO team_draft_revisions
+           (id, draft_id, author_user_id, summary, kind, details, content_snapshot, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+        (
+            str(uuid.uuid4()),
+            draft_id,
+            user_id,
+            f"Applied template '{template_row['name']}'",
+            'template_apply',
+            json.dumps({'template_id': template_id, 'scope': template_row['scope']}),
+            previous_snapshot,
+            now_iso
+        )
+    )
+    db.commit()
+
+    updated_draft = row_to_mapping(
+        db.execute('SELECT * FROM team_drafts WHERE id = ?', (draft_id,)).fetchone()
+    ) or {}
+    updated_draft['content'] = _deserialize_json(updated_draft.get('content'), [])
+    return jsonify({'ok': True, 'draft': updated_draft})
+
+
+@app.post('/api/drafts/<draft_id>/undo-template')
+def api_undo_template_apply(draft_id):
+    user_id = _current_user_id()
+    if not user_id:
+        return jsonify({'ok': False, 'error': 'Unauthorized'}), 401
+
+    db = get_db()
+    draft_row = db.execute(
+        'SELECT * FROM team_drafts WHERE id = ? AND owner_user_id = ?',
+        (draft_id, user_id)
+    ).fetchone()
+    if not draft_row:
+        return jsonify({'ok': False, 'error': 'Draft not found'}), 404
+
+    revision = db.execute(
+        '''SELECT * FROM team_draft_revisions
+           WHERE draft_id = ? AND author_user_id = ? AND kind = 'template_apply'
+           ORDER BY created_at DESC LIMIT 1''',
+        (draft_id, user_id)
+    ).fetchone()
+    if not revision:
+        return jsonify({'ok': False, 'error': 'No template application to undo'}), 400
+
+    previous_snapshot = revision['content_snapshot'] or '[]'
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    db.execute(
+        'UPDATE team_drafts SET content = ?, updated_at = ? WHERE id = ?',
+        (previous_snapshot, now_iso, draft_id)
+    )
+    db.execute(
+        '''INSERT INTO team_draft_revisions
+           (id, draft_id, author_user_id, summary, kind, details, content_snapshot, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+        (
+            str(uuid.uuid4()),
+            draft_id,
+            user_id,
+            'Reverted template application',
+            'template_undo',
+            json.dumps({'reverted_revision': revision['id']}),
+            previous_snapshot,
+            now_iso
+        )
+    )
+    db.commit()
+
+    updated_draft = row_to_mapping(
+        db.execute('SELECT * FROM team_drafts WHERE id = ?', (draft_id,)).fetchone()
+    ) or {}
+    updated_draft['content'] = _deserialize_json(updated_draft.get('content'), [])
+    return jsonify({'ok': True, 'draft': updated_draft})
 
 
 @app.post('/api/feedback/report')

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -100,6 +100,7 @@ const templateLibraryState = {
   lastUsed: null,
   profileKey: 'anon'
 };
+let lastTemplateUndoState = null;
 const platformPresetState = {
   wizard: [],
   lastPlan: null
@@ -1102,22 +1103,56 @@ function setupQuickActions() {
   quick30Day?.addEventListener('click', () => handleShortcut(30, 'Create a free account to unlock plans.'));
 }
 
-function hydrateTemplateLibrary() {
+async function hydrateTemplateLibrary() {
   loadTemplateLibraryState();
   renderTemplatePicker();
   renderPresetButtons();
   renderCollaborationSummary();
+  await refreshTemplatesFromServer();
 }
 
 function setupTemplateLibrary() {
   const saveBtn = document.getElementById('save-template');
   const applyBtn = document.getElementById('apply-template');
   const picker = document.getElementById('template-picker');
+  const openModalBtn = document.getElementById('open-template-modal');
+  const modalClose = document.getElementById('template-modal-close');
+  const modalCancel = document.getElementById('template-modal-cancel');
+  const modalSave = document.getElementById('template-modal-save');
+  const undoBtn = document.getElementById('undo-template');
+
   hydrateTemplateLibrary();
 
-  saveBtn?.addEventListener('click', () => saveCurrentTemplate());
+  saveBtn?.addEventListener('click', () => openTemplateModal());
+  openModalBtn?.addEventListener('click', () => openTemplateModal());
+  modalClose?.addEventListener('click', () => closeTemplateModal());
+  modalCancel?.addEventListener('click', () => closeTemplateModal());
+  modalSave?.addEventListener('click', () => saveCurrentTemplateFromModal());
   applyBtn?.addEventListener('click', () => applySelectedTemplate());
-  picker?.addEventListener('change', () => updateTemplateEmptyState());
+  picker?.addEventListener('change', () => handleTemplateSelectionChange());
+  undoBtn?.addEventListener('click', () => undoTemplateApplication());
+}
+
+async function refreshTemplatesFromServer() {
+  try {
+    const res = await fetch('/api/templates', { credentials: 'same-origin' });
+    if (!res.ok) throw new Error('Failed to load templates');
+    const data = await res.json();
+    if (Array.isArray(data.templates)) {
+      templateLibraryState.templates = data.templates.map(tpl => Object.assign({
+        updatedAt: tpl.updated_at || tpl.updatedAt || Date.now(),
+        author: tpl.author || getCurrentUserName() || 'Shared profile'
+      }, tpl));
+      renderTemplatePicker();
+      renderCollaborationSummary();
+      renderTemplatePreview(getSelectedTemplate());
+      persistTemplateLibraryState();
+    }
+  } catch (err) {
+    // fallback to local storage when offline
+    renderTemplatePicker();
+    renderTemplatePreview(getSelectedTemplate());
+  }
 }
 
 function renderTemplatePicker() {
@@ -1133,11 +1168,14 @@ function renderTemplatePicker() {
     const template = Object.assign({ updatedAt: Date.now() }, tpl);
     const opt = document.createElement('option');
     opt.value = template.id;
-    opt.textContent = template.author ? `${template.name} • ${template.author}` : template.name;
+    const scopeLabel = template.scope === 'workspace' ? 'Workspace' : 'Personal';
+    opt.textContent = template.author ? `${template.name} • ${scopeLabel}` : `${template.name} (${scopeLabel})`;
     opt.dataset.platforms = (template.platforms || []).join(',');
+    opt.dataset.scope = template.scope || 'personal';
     picker.appendChild(opt);
   });
   updateTemplateEmptyState(emptyState);
+  handleTemplateSelectionChange();
 }
 
 function renderCollaborationSummary() {
@@ -1187,88 +1225,247 @@ function updateTemplateEmptyState(target) {
   emptyState.classList.toggle('hidden', !!hasItems);
 }
 
-function saveCurrentTemplate() {
-  const nameField = document.getElementById('template-name');
-  const name = (nameField?.value || '').trim();
-  if (!name) {
-    showToast('Name your template first.');
-    nameField?.focus();
-    return;
+function getSelectedTemplate() {
+  const picker = document.getElementById('template-picker');
+  if (!picker) return null;
+  const selectedId = picker.value;
+  if (!selectedId) return null;
+  return (templateLibraryState.templates || []).find(t => t.id === selectedId) || null;
+}
+
+function handleTemplateSelectionChange() {
+  renderTemplatePreview(getSelectedTemplate());
+  updateTemplateEmptyState();
+}
+
+function buildTemplatePreviewText(state = {}) {
+  const parts = [];
+  if (state.tone) parts.push(`Tone: ${state.tone}`);
+  if (Array.isArray(state.platforms) && state.platforms.length) {
+    parts.push(`Platforms: ${state.platforms.join(', ')}`);
   }
-  const baseTemplate = {
-    id: `tpl-${Date.now()}`,
-    name,
+  if (Array.isArray(state.goals) && state.goals.length) {
+    parts.push(`Goals: ${state.goals.join(', ')}`);
+  }
+  if (Array.isArray(state.keywords) && state.keywords.length) {
+    parts.push(`Keywords: ${state.keywords.join(', ')}`);
+  }
+  return parts.join(' • ') || 'Tone, platforms, and goals from your current draft will be saved.';
+}
+
+function captureCurrentGeneratorState() {
+  return {
     tone: document.getElementById('gen-tone')?.value || 'friendly',
     platforms: getGeneratorPlatformSelections(),
     goals: getCurrentGoals(),
     keywords: getCurrentKeywords(),
-    author: getCurrentUserName() || 'Shared profile',
-    updatedAt: Date.now()
+    planLength: getCurrentPlanLength()
   };
-  const existingIdx = (templateLibraryState.templates || []).findIndex(t => t.name.toLowerCase() === name.toLowerCase());
+}
+
+function openTemplateModal() {
+  const modal = document.getElementById('template-modal');
+  const nameField = document.getElementById('template-modal-name');
+  const preview = document.getElementById('template-modal-preview');
+  if (!modal) return;
+  preview.textContent = buildTemplatePreviewText(captureCurrentGeneratorState());
+  modal.classList.remove('hidden');
+  modal.setAttribute('aria-hidden', 'false');
+  nameField.value = '';
+  nameField.focus();
+}
+
+function closeTemplateModal() {
+  const modal = document.getElementById('template-modal');
+  if (!modal) return;
+  modal.classList.add('hidden');
+  modal.setAttribute('aria-hidden', 'true');
+}
+
+async function saveCurrentTemplateFromModal() {
+  const nameField = document.getElementById('template-modal-name');
+  const scopeField = document.getElementById('template-modal-scope');
+  const name = (nameField?.value || '').trim();
+  const scope = (scopeField?.value || 'personal').trim();
+  await saveCurrentTemplate({ name, scope });
+}
+
+function addTemplateToState(template) {
+  const nameKey = (template.name || '').toLowerCase();
+  const existingIdx = (templateLibraryState.templates || []).findIndex(t => (t.name || '').toLowerCase() === nameKey);
   if (existingIdx >= 0) {
-    const existing = templateLibraryState.templates[existingIdx] || {};
-    templateLibraryState.templates[existingIdx] = Object.assign({}, existing, baseTemplate, {
-      id: existing.id || baseTemplate.id
-    });
+    templateLibraryState.templates[existingIdx] = Object.assign({}, templateLibraryState.templates[existingIdx], template);
   } else {
-    templateLibraryState.templates = [...(templateLibraryState.templates || []), baseTemplate];
+    templateLibraryState.templates = [...(templateLibraryState.templates || []), template];
   }
-  lastGeneratorState = Object.assign({}, baseTemplate, { planLength: getCurrentPlanLength() });
-  persistTemplateLibraryState();
   renderTemplatePicker();
   renderCollaborationSummary();
+  renderTemplatePreview(getSelectedTemplate());
+  persistTemplateLibraryState();
+}
+
+async function saveCurrentTemplate(opts = {}) {
+  const name = (opts.name || '').trim();
+  if (!name) {
+    showToast('Name your template first.');
+    return;
+  }
+  const generatorState = captureCurrentGeneratorState();
+  const payload = {
+    generator: generatorState,
+    profile_defaults: profileDefaults || {},
+    draft: planCacheState.meta || {}
+  };
+  const baseTemplate = {
+    id: opts.id || `tpl-${Date.now()}`,
+    name,
+    scope: opts.scope || 'personal',
+    author: getCurrentUserName() || 'Shared profile',
+    payload,
+    preview: buildTemplatePreviewText(generatorState),
+    updatedAt: Date.now()
+  };
+  let savedTemplate = baseTemplate;
+  try {
+    const res = await fetch('/api/templates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'same-origin',
+      body: JSON.stringify({
+        name,
+        scope: baseTemplate.scope,
+        payload,
+        preview: baseTemplate.preview
+      })
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data?.template) {
+        savedTemplate = Object.assign({}, baseTemplate, data.template, {
+          payload: data.template.payload || baseTemplate.payload
+        });
+      }
+    }
+  } catch (error) {
+    console.error('Template save failed, keeping local copy', error);
+  }
+
+  lastGeneratorState = Object.assign({}, generatorState, {
+    planLength: generatorState.planLength,
+    updatedAt: savedTemplate.updatedAt,
+    author: savedTemplate.author,
+    name: savedTemplate.name
+  });
+  addTemplateToState(savedTemplate);
+  closeTemplateModal();
   showToast('Template saved for this profile.');
 }
 
+function renderTemplatePreview(tpl) {
+  const preview = document.getElementById('template-preview');
+  if (!preview) return;
+  if (!tpl) {
+    preview.innerHTML = '<p class="text-sm font-semibold text-slate-900">No templates yet</p><p class="text-xs text-slate-600">Save your first template to preview tone, platforms, and goals before applying.</p>';
+    document.getElementById('undo-template')?.classList.add('hidden');
+    return;
+  }
+  const generatorPayload = extractGeneratorPayload(tpl);
+  const previewText = buildTemplatePreviewText(generatorPayload || {});
+  const scopeLabel = tpl.scope === 'workspace' ? 'Workspace' : 'Personal';
+  preview.innerHTML = `
+    <div class="flex items-start justify-between gap-3">
+      <div>
+        <p class="text-xs uppercase tracking-wide text-slate-500">${scopeLabel} template</p>
+        <p class="text-sm font-semibold text-slate-900">${escapeHtml(tpl.name || 'Untitled')}</p>
+        <p class="text-xs text-slate-600">${escapeHtml(previewText)}</p>
+      </div>
+      <span class="text-[11px] px-2 py-1 rounded-full bg-slate-100 text-slate-600">${tpl.author || 'Shared profile'}</span>
+    </div>`;
+}
+
 function applySelectedTemplate() {
-  const picker = document.getElementById('template-picker');
-  if (!picker) return;
-  const selectedId = picker.value;
-  const tpl = (templateLibraryState.templates || []).find(t => t.id === selectedId);
+  const tpl = getSelectedTemplate();
   if (!tpl) {
     showToast('Pick a template to apply.');
     return;
   }
-  applyTemplateToGenerator(tpl);
+  applyTemplateWithUndo(tpl);
   renderCollaborationSummary();
+}
+
+function extractGeneratorPayload(tpl = {}) {
+  if (tpl.payload && typeof tpl.payload === 'object') {
+    if (tpl.payload.generator) return tpl.payload.generator;
+    if (tpl.payload.config) return tpl.payload.config;
+  }
+  if (tpl.generator) return tpl.generator;
+  return tpl;
+}
+
+function applyTemplateWithUndo(tpl) {
+  const generatorPayload = extractGeneratorPayload(tpl);
+  const previousState = captureCurrentGeneratorState();
+  applyTemplateToGenerator(generatorPayload);
+  lastTemplateUndoState = previousState;
+  const undoBtn = document.getElementById('undo-template');
+  undoBtn?.classList.remove('hidden');
+  showToast('Template applied. Undo to restore previous draft.');
+}
+
+function undoTemplateApplication() {
+  if (!lastTemplateUndoState) {
+    showToast('No template change to undo.');
+    return;
+  }
+  applyGeneratorState(lastTemplateUndoState, { sync: true });
+  lastTemplateUndoState = null;
+  document.getElementById('undo-template')?.classList.add('hidden');
+  showToast('Template reverted.');
 }
 
 function applyPresetTemplate(preset) {
   const tpl = {
     id: preset.id,
     name: preset.label,
-    tone: preset.tone,
-    platforms: getGeneratorPlatformSelections(),
-    goals: preset.goals,
-    keywords: preset.keywords,
+    payload: {
+      generator: {
+        tone: preset.tone,
+        platforms: getGeneratorPlatformSelections(),
+        goals: preset.goals,
+        keywords: preset.keywords
+      }
+    },
     author: 'Team preset',
     updatedAt: Date.now()
   };
-  applyTemplateToGenerator(tpl, { skipPlatform: false });
+  applyTemplateWithUndo(tpl);
   renderCollaborationSummary();
 }
 
 function applyTemplateToGenerator(tpl, opts = {}) {
   if (!tpl) return;
-  if (tpl.tone) {
+  const generatorConfig = tpl.generator || tpl.payload?.generator || tpl;
+  if (generatorConfig.tone) {
     const toneField = document.getElementById('gen-tone');
-    if (toneField) toneField.value = tpl.tone;
+    if (toneField) toneField.value = generatorConfig.tone;
   }
-  if (!opts.skipPlatform && Array.isArray(tpl.platforms) && tpl.platforms.length) {
-    setGeneratorPlatformSelections(tpl.platforms);
+  if (!opts.skipPlatform && Array.isArray(generatorConfig.platforms) && generatorConfig.platforms.length) {
+    setGeneratorPlatformSelections(generatorConfig.platforms);
   }
-  if (Array.isArray(tpl.goals)) setCurrentGoals(tpl.goals);
-  if (Array.isArray(tpl.keywords)) setCurrentKeywords(tpl.keywords);
+  if (Array.isArray(generatorConfig.goals)) setCurrentGoals(generatorConfig.goals);
+  if (Array.isArray(generatorConfig.keywords)) setCurrentKeywords(generatorConfig.keywords);
+  if (generatorConfig.planLength) {
+    updateGeneratorShortcut(generatorConfig.planLength, { skipFocus: true, skipScroll: true });
+  }
   syncPreferredPlatformButtons();
   refreshReelOptionsVisibility();
-  lastGeneratorState = Object.assign({}, tpl, {
-    planLength: getCurrentPlanLength(),
-    updatedAt: tpl.updatedAt || Date.now(),
-    author: tpl.author || getCurrentUserName() || 'Shared profile'
+  lastGeneratorState = Object.assign({}, generatorConfig, {
+    planLength: generatorConfig.planLength || getCurrentPlanLength(),
+    updatedAt: generatorConfig.updatedAt || Date.now(),
+    author: generatorConfig.author || tpl.author || getCurrentUserName() || 'Shared profile',
+    name: tpl.name || generatorConfig.name
   });
   persistTemplateLibraryState();
-  showToast('Template applied.');
 }
 
 function setupOneClickGeneration() {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -261,20 +261,24 @@
                   <label for="template-picker" class="block text-xs uppercase tracking-wide text-slate-500">Template library</label>
                   <div class="flex flex-col gap-2 bg-slate-50 border border-slate-200 rounded-2xl p-3">
                     <div class="flex items-center gap-2">
-                      <select id="template-picker" class="planner-select flex-1"></select>
-                      <button id="apply-template" class="btn-secondary btn-sm" type="button">Apply</button>
+                      <select id="template-picker" class="planner-select flex-1" aria-describedby="template-empty"></select>
+                      <button id="apply-template" class="btn-secondary btn-sm" type="button">Preview &amp; apply</button>
+                      <button id="undo-template" class="btn-ghost btn-sm hidden" type="button">Undo</button>
                     </div>
                     <div class="flex flex-wrap gap-2" id="template-preset-buttons" aria-label="Quick presets"></div>
-                    <p id="template-empty" class="planner-hint">Save combinations per profile to reuse launch or update prompts.</p>
+                    <div id="template-preview" class="rounded-xl border border-dashed border-slate-200 bg-white/80 p-3">
+                      <p class="text-sm font-semibold text-slate-900">No templates yet</p>
+                      <p class="text-xs text-slate-600">Save your first template to preview tone, platforms, and goals before applying.</p>
+                    </div>
+                    <p id="template-empty" class="planner-hint">Save your first template to reuse launch or update prompts.</p>
                   </div>
                 </div>
                 <div class="space-y-2">
-                  <label for="template-name" class="block text-xs uppercase tracking-wide text-slate-500">Save current as</label>
+                  <label class="block text-xs uppercase tracking-wide text-slate-500">Save current as</label>
                   <div class="flex items-center gap-2">
-                    <input id="template-name" class="planner-select flex-1" placeholder="e.g. Instagram launch push" />
-                    <button id="save-template" class="btn-primary btn-sm" type="button">Save</button>
+                    <button id="open-template-modal" class="btn-primary btn-sm" type="button">Save current as…</button>
                   </div>
-                  <p class="planner-hint">Templates capture tone, platforms, goals, and keywords for the active profile.</p>
+                  <p class="planner-hint">Templates capture tone, platforms, goals, and keywords for the active profile. Name is required.</p>
                 </div>
               </div>
 
@@ -671,6 +675,37 @@
 
   <script src="/static/app.js"></script>
   <script src="/static/dashboard.js"></script>
+
+  <div id="template-modal" class="fixed inset-0 bg-slate-900/40 backdrop-blur-sm flex items-center justify-center p-4 hidden" aria-hidden="true">
+    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg border border-slate-200">
+      <div class="flex items-start justify-between p-4 border-b border-slate-200">
+        <div>
+          <p class="text-xs uppercase tracking-wide text-slate-500">Save template</p>
+          <h3 class="text-lg font-semibold text-slate-900">Save current setup as a reusable template</h3>
+        </div>
+        <button type="button" id="template-modal-close" class="text-slate-400 hover:text-slate-600" aria-label="Close">✕</button>
+      </div>
+      <div class="p-4 space-y-4">
+        <label class="block text-sm font-medium text-slate-700">Name (required)
+          <input type="text" id="template-modal-name" class="mt-1 w-full input" placeholder="e.g. Product launch warmup" required />
+        </label>
+        <label class="block text-sm font-medium text-slate-700">Scope
+          <select id="template-modal-scope" class="mt-1 w-full input">
+            <option value="personal">Personal</option>
+            <option value="workspace">Workspace</option>
+          </select>
+        </label>
+        <div class="rounded-xl border border-slate-200 bg-slate-50 p-3">
+          <p class="text-xs uppercase tracking-wide text-slate-500">Preview</p>
+          <p id="template-modal-preview" class="text-sm text-slate-700">Tone, platforms, and goals from your current draft will be saved.</p>
+        </div>
+      </div>
+      <div class="flex items-center justify-end gap-2 px-4 py-3 border-t border-slate-200 bg-slate-50">
+        <button type="button" id="template-modal-cancel" class="btn-ghost btn-sm">Cancel</button>
+        <button type="button" id="template-modal-save" class="btn-primary btn-sm">Save template</button>
+      </div>
+    </div>
+  </div>
 
   {% include 'paywall_modal.html' %}
 </body>

--- a/tests/test_templates_apply_updates_draft.py
+++ b/tests/test_templates_apply_updates_draft.py
@@ -1,0 +1,48 @@
+import json
+import uuid
+from datetime import datetime, timezone
+import app as togetherly_app
+
+
+def test_templates_apply_updates_draft(client):
+    signup_resp = client.post('/api/signup', json={'email': 'apply@example.com', 'password': 'secret123'})
+    user_id = signup_resp.get_json()['id']
+
+    template_payload = {
+        'generator': {
+            'tone': 'playful',
+            'platforms': ['linkedin'],
+            'goals': ['Hiring'],
+            'keywords': ['team growth']
+        },
+        'draft': [
+            {'id': 'hook', 'heading': 'Hook', 'text': 'New hook from template'},
+            {'id': 'cta', 'heading': 'CTA', 'text': 'Join us today'}
+        ]
+    }
+    template_resp = client.post('/api/templates', json={
+        'name': 'Team update',
+        'payload': template_payload,
+        'preview': 'Tone: playful'
+    })
+    template_id = template_resp.get_json()['template']['id']
+
+    draft_id = str(uuid.uuid4())
+    now_iso = datetime.now(timezone.utc).isoformat()
+    with client.application.app_context():
+        db = togetherly_app.get_db()
+        db.execute(
+            'INSERT INTO team_drafts (id, owner_user_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+            (draft_id, user_id, 'Initial Draft', json.dumps([{'id': 'hook', 'text': 'Old hook'}]), now_iso, now_iso)
+        )
+        db.commit()
+
+    apply_resp = client.post(f'/api/templates/{template_id}/apply', json={'draft_id': draft_id})
+    assert apply_resp.status_code == 200
+    applied = apply_resp.get_json()['draft']
+    assert applied['content'][0]['text'] == 'New hook from template'
+
+    undo_resp = client.post(f'/api/drafts/{draft_id}/undo-template')
+    assert undo_resp.status_code == 200
+    reverted = undo_resp.get_json()['draft']
+    assert reverted['content'][0]['text'] == 'Old hook'

--- a/tests/test_templates_crud.py
+++ b/tests/test_templates_crud.py
@@ -1,0 +1,51 @@
+import json
+import uuid
+import app as togetherly_app
+
+
+def signup(client, email='user@example.com'):
+    return client.post('/api/signup', json={'email': email, 'password': 'secret123'})
+
+
+def create_template(client, name='Launch kit', scope='personal'):
+    payload = {
+        'generator': {
+            'tone': 'friendly',
+            'platforms': ['instagram'],
+            'goals': ['Launch'],
+            'keywords': ['buzz']
+        }
+    }
+    return client.post('/api/templates', json={
+        'name': name,
+        'scope': scope,
+        'payload': payload,
+        'preview': 'Tone: friendly'
+    })
+
+
+def test_templates_crud(client):
+    signup(client)
+
+    create_resp = create_template(client)
+    assert create_resp.status_code == 201
+    created = create_resp.get_json()['template']
+    template_id = created['id']
+
+    list_resp = client.get('/api/templates')
+    assert list_resp.status_code == 200
+    listed = list_resp.get_json()['templates']
+    assert len(listed) == 1
+    assert listed[0]['name'] == 'Launch kit'
+
+    detail_resp = client.get(f'/api/templates/{template_id}')
+    assert detail_resp.status_code == 200
+    detail = detail_resp.get_json()['template']
+    assert detail['payload']['generator']['tone'] == 'friendly'
+
+    delete_resp = client.delete(f'/api/templates/{template_id}')
+    assert delete_resp.status_code == 200
+
+    list_after_delete = client.get('/api/templates')
+    assert list_after_delete.status_code == 200
+    assert list_after_delete.get_json()['templates'] == []

--- a/tests/test_templates_permissions.py
+++ b/tests/test_templates_permissions.py
@@ -1,0 +1,43 @@
+import json
+import uuid
+from datetime import datetime, timezone
+import app as togetherly_app
+
+
+def _insert_draft(app_ctx, draft_id, owner_id, text):
+    db = togetherly_app.get_db()
+    now_iso = datetime.now(timezone.utc).isoformat()
+    db.execute(
+        'INSERT INTO team_drafts (id, owner_user_id, title, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+        (draft_id, owner_id, 'Secure Draft', json.dumps([{'id': 'section', 'text': text}]), now_iso, now_iso)
+    )
+    db.commit()
+
+
+def test_templates_permissions(client):
+    first_resp = client.post('/api/signup', json={'email': 'owner@example.com', 'password': 'secret123'})
+    owner_id = first_resp.get_json()['id']
+    template_resp = client.post('/api/templates', json={
+        'name': 'Owner only',
+        'payload': {'generator': {'tone': 'friendly'}},
+        'preview': 'Tone: friendly'
+    })
+    template_id = template_resp.get_json()['template']['id']
+
+    client.post('/api/logout')
+    second_resp = client.post('/api/signup', json={'email': 'other@example.com', 'password': 'secret123'})
+    other_id = second_resp.get_json()['id']
+
+    forbidden_detail = client.get(f'/api/templates/{template_id}')
+    assert forbidden_detail.status_code == 404
+
+    draft_id = str(uuid.uuid4())
+    with client.application.app_context():
+        _insert_draft(client.application, draft_id, other_id, 'other draft')
+
+    apply_resp = client.post(f'/api/templates/{template_id}/apply', json={'draft_id': draft_id})
+    assert apply_resp.status_code == 404
+
+    list_resp = client.get('/api/templates')
+    assert list_resp.status_code == 200
+    assert list_resp.get_json()['templates'] == []

--- a/tests/test_templates_validation_name_required.py
+++ b/tests/test_templates_validation_name_required.py
@@ -1,0 +1,7 @@
+def test_template_name_required(client):
+    client.post('/api/signup', json={'email': 'namecheck@example.com', 'password': 'secret123'})
+    resp = client.post('/api/templates', json={'payload': {'generator': {}}})
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data['ok'] is False
+    assert 'Name is required' in data['error']


### PR DESCRIPTION
## Summary
- add backend endpoints to store, fetch, apply, and delete templates with undoable draft updates
- add dashboard modal, previews, and undo state so templates can be saved and applied safely
- cover CRUD, validation, apply/undo, and permission cases with new template-focused tests

## Testing
- pytest tests/test_templates_*.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d769436e083289bd17474dac9d9d7)